### PR TITLE
JCES-1287: Re-enable diagnostics, even for prod Cloud instances

### DIFF
--- a/src/test/kotlin/JiraPerformanceComparisonIT.kt
+++ b/src/test/kotlin/JiraPerformanceComparisonIT.kt
@@ -19,7 +19,6 @@ import jces1209.vu.JiraDcScenario
 import org.apache.logging.log4j.core.config.ConfigurationFactory
 import org.junit.Test
 import java.io.File
-import java.net.URI
 import java.nio.file.Paths
 import java.time.Duration
 import java.util.concurrent.CompletableFuture
@@ -98,17 +97,8 @@ class JiraPerformanceComparisonIT {
         )
         val behavior = quality.behave(scenario)
             .let { VirtualUserBehavior.Builder(it) }
-            .avoidLeakingPersonalData(properties.jira)
             .build()
         return VirtualUserOptions(target, behavior)
-    }
-
-    private fun VirtualUserBehavior.Builder.avoidLeakingPersonalData(
-        uri: URI
-    ) = apply {
-        if (uri.host.endsWith("atlassian.net")) {
-            diagnosticsLimit(0)
-        }
     }
 
     private fun dumpMegaSlowWaterfalls(


### PR DESCRIPTION
Diagnostics are needed to hunt down the errors.
Some sensitive data is leaked via other means, not only diagnoses:
* virtual-users.log - URLs containing issue keys, bot password
* action-metrics.jpt - JQL observations

So we'll have to be careful when sharing raw results (like attaching to Jira issues).
We should nuke the `vu-results` dir before zipping and sending it outside of our workstations.