### PR TITLE
Page load concept

### DIFF
--- a/custom-vu/src/main/kotlin/jces1209/vu/page/FalliblePage.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/page/FalliblePage.kt
@@ -1,0 +1,66 @@
+package jces1209.vu.page
+
+import org.openqa.selenium.By
+import org.openqa.selenium.WebDriver
+import org.openqa.selenium.support.ui.ExpectedConditions.or
+import org.openqa.selenium.support.ui.ExpectedConditions.visibilityOfElementLocated
+import com.atlassian.performance.tools.jiraactions.api.page.wait
+import org.openqa.selenium.support.ui.ExpectedCondition
+import java.time.Duration
+
+class FalliblePage private constructor(
+    private val webDriver: WebDriver,
+    private val expectedContent: List<By>,
+    private val potentialErrors: List<By>,
+    private val loadTimeout: Duration
+) {
+
+    fun waitForPageToLoad() {
+        webDriver.wait(
+            condition = (expectedContent + potentialErrors).anyElementVisible(),
+            timeout = loadTimeout
+        )
+        assertNoErrors()
+    }
+
+    
+    private fun assertNoErrors() {
+        potentialErrors.forEach { locator ->
+            webDriver.findElements(locator).firstOrNull()?.let { element ->
+                throw FallibleException(element.text)
+            }
+        }
+    }
+
+    private fun List<By>.anyElementVisible(): ExpectedCondition<Boolean> {
+        return or(*this.map { visibilityOfElementLocated(it) }.toTypedArray())
+    }
+
+    class FallibleException(elementText: String) : Exception("Error page detected by \"$elementText\"")
+
+    class Builder(
+        private val webDriver: WebDriver,
+        private val expectedContent: List<By>
+    ) {
+        private var loadTimeout: Duration = Duration.ofSeconds(10)
+        private var potentialErrors: List<By> = emptyList()
+
+        fun timeout(timeout: Duration) = apply { this.loadTimeout = timeout }
+        fun potentialErrors(potentialErrors: List<By>) = apply { this.potentialErrors = potentialErrors }
+
+        fun cloudErrors() = potentialErrors(
+            listOf(
+                By.xpath("//*[contains(text(), \"We couldn't connect to that issue\")]"),
+                By.xpath("//*[contains(text(), \"429 - Too many requests\")]"),
+                By.xpath("//*[contains(text(), \"Something's gone wrong\")]")
+            )
+        )
+
+        fun build(): FalliblePage = FalliblePage(
+            webDriver = webDriver,
+            expectedContent = expectedContent,
+            potentialErrors = potentialErrors,
+            loadTimeout = loadTimeout
+        )
+    }
+}

--- a/custom-vu/src/main/kotlin/jces1209/vu/page/boards/ClassicBoardPage.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/page/boards/ClassicBoardPage.kt
@@ -1,27 +1,29 @@
 package jces1209.vu.page.boards
 
-import jces1209.vu.wait
+import jces1209.vu.page.FalliblePage
 import org.openqa.selenium.By
 import org.openqa.selenium.WebDriver
-import org.openqa.selenium.support.ui.ExpectedConditions.or
-import org.openqa.selenium.support.ui.ExpectedConditions.presenceOfElementLocated
 import java.net.URI
 
 internal class ClassicBoardPage(
     private val driver: WebDriver,
     override val uri: URI
 ) : BoardPage {
-    private val boardLoadedLocators = listOf(
-        By.xpath("//*[contains(text(), 'Your board has too many issues')]"),
-        By.xpath("//*[contains(text(), 'Board not accessible')]"),
-        By.xpath("//*[contains(text(), 'Set a new location for your board')]"),
-        By.cssSelector(".ghx-column")
+
+    private val falliblePage = FalliblePage.Builder(
+        webDriver = driver,
+        expectedContent = listOf(
+            By.xpath("//*[contains(text(), 'Your board has too many issues')]"),
+            By.xpath("//*[contains(text(), 'Board not accessible')]"),
+            By.xpath("//*[contains(text(), 'Set a new location for your board')]"),
+            By.cssSelector(".ghx-column")
+        )
     )
+        .cloudErrors()
+        .build()
 
     override fun waitForBoardPageToLoad(): BoardContent {
-        driver.wait(
-            or(*boardLoadedLocators.map { presenceOfElementLocated(it) }.toTypedArray())
-        )
+        falliblePage.waitForPageToLoad()
         return KanbanBoardContent(driver)
     }
 

--- a/custom-vu/src/main/kotlin/jces1209/vu/page/boards/NextGenBoardPage.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/page/boards/NextGenBoardPage.kt
@@ -1,30 +1,32 @@
 package jces1209.vu.page.boards
 
-import jces1209.vu.wait
+import jces1209.vu.page.FalliblePage
 import org.openqa.selenium.By
 import org.openqa.selenium.WebDriver
 import org.openqa.selenium.WebElement
-import org.openqa.selenium.support.ui.ExpectedConditions.or
-import org.openqa.selenium.support.ui.ExpectedConditions.presenceOfElementLocated
 import java.net.URI
 
 class NextGenBoardPage(
     private val driver: WebDriver,
     override val uri: URI
 ) : BoardPage {
-    private val boardLoadedLocators = listOf(
-        By.xpath("//*[contains(text(), 'Your board has too many issues')]"),
-        By.xpath("//*[contains(text(), 'Board not accessible')]"),
-        By.cssSelector("[data-test-id='platform-board-kit.common.ui.column-header.header.column-header-container']")
+
+    private val falliblePage = FalliblePage.Builder(
+        webDriver = driver,
+        expectedContent = listOf(
+            By.xpath("//*[contains(text(), 'Your board has too many issues')]"),
+            By.xpath("//*[contains(text(), 'Board not accessible')]"),
+            By.cssSelector("[data-test-id='platform-board-kit.common.ui.column-header.header.column-header-container']")
+        )
     )
+        .cloudErrors()
+        .build()
 
     override fun waitForBoardPageToLoad(): BoardContent {
         driver.get(uri.toString())
         closeModals()
 
-        driver.wait(
-            or(*boardLoadedLocators.map { presenceOfElementLocated(it) }.toTypedArray())
-        )
+        falliblePage.waitForPageToLoad()
 
         val issueCards = findIssueCards()
         return NextGenBoardContent(issueCards)


### PR DESCRIPTION
This one is just a concept for your consideration. It came from:
* I have seen some common patterns for waiting for pages too load BoardPage is just an example usage. There are more that could be changed into that.
* It would allow easy enabling/disabling yield before timeout on errors (i'm not sure if in some places used JiraErrors::anyCommonError is aplicable to cloud

Those are just some ideas 