### PR TITLE
Increased fallible page coverage

### DIFF
--- a/custom-vu/src/main/kotlin/jces1209/vu/action/BrowseCloudProjects.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/action/BrowseCloudProjects.kt
@@ -17,8 +17,7 @@ class BrowseCloudProjects(
     override fun run() {
         val projectList = meter.measure(BROWSE_PROJECTS) {
             jira.navigateTo("projects")
-            JiraCloudProjectList(jira.driver)
-                .lookForProjects(Duration.ofSeconds(10))
+            JiraCloudProjectList(jira.driver).lookForProjects()
         }
         projectMemory.remember(projectList.listProjects())
     }

--- a/custom-vu/src/main/kotlin/jces1209/vu/page/CloudBrowseBoardsPage.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/page/CloudBrowseBoardsPage.kt
@@ -1,9 +1,7 @@
 package jces1209.vu.page
 
-import com.atlassian.performance.tools.jiraactions.api.page.wait
 import org.openqa.selenium.By
 import org.openqa.selenium.WebDriver
-import org.openqa.selenium.support.ui.ExpectedConditions.visibilityOfElementLocated
 import java.time.Duration
 
 class CloudBrowseBoardsPage(
@@ -13,11 +11,17 @@ class CloudBrowseBoardsPage(
         "[data-test-id='global-pages.directories.directory-base.content.table.container']"
     )
 
+    private val falliblePage = FalliblePage.Builder(
+        expectedContent = listOf(tableLocator),
+        webDriver = driver
+    )
+        .cloudErrors()
+        .timeout(Duration.ofSeconds(25))
+        .build()
+
     fun waitForBoards(): CloudBoardList {
-        val tableElement = driver.wait(
-            condition = visibilityOfElementLocated(tableLocator),
-            timeout = Duration.ofSeconds(25)
-        )
+        falliblePage.waitForPageToLoad()
+        val tableElement = driver.findElement(tableLocator)
         return CloudBoardList(tableElement, driver)
     }
 }

--- a/custom-vu/src/main/kotlin/jces1209/vu/page/CloudIssuePage.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/page/CloudIssuePage.kt
@@ -1,24 +1,22 @@
 package jces1209.vu.page
 
-import jces1209.vu.wait
 import org.openqa.selenium.By
 import org.openqa.selenium.WebDriver
-import org.openqa.selenium.support.ui.ExpectedConditions.or
-import org.openqa.selenium.support.ui.ExpectedConditions.visibilityOfElementLocated
 
 class CloudIssuePage(
     private val driver: WebDriver
 ) : AbstractIssuePage {
     private val bentoSummary = By.cssSelector("[data-test-id='issue.views.issue-base.foundation.summary.heading']")
     private val classicSummary = By.id("key-val")
+    private val falliblePage = FalliblePage.Builder(
+        expectedContent = listOf(bentoSummary, classicSummary),
+        webDriver = driver
+    )
+        .cloudErrors()
+        .build()
 
     override fun waitForSummary(): AbstractIssuePage {
-        driver.wait(
-            or(
-                visibilityOfElementLocated(bentoSummary),
-                visibilityOfElementLocated(classicSummary)
-            )
-        )
+        falliblePage.waitForPageToLoad()
         return this
     }
 

--- a/custom-vu/src/main/kotlin/jces1209/vu/page/FalliblePage.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/page/FalliblePage.kt
@@ -56,6 +56,14 @@ class FalliblePage private constructor(
             )
         )
 
+        fun serverErrors() = potentialErrors(
+            listOf(
+                By.cssSelector("section div.aui-message.error"),
+                By.id("errorPageContainer"),
+                By.cssSelector("div.form-body div.error")
+            )
+        )
+
         fun build(): FalliblePage = FalliblePage(
             webDriver = webDriver,
             expectedContent = expectedContent,

--- a/custom-vu/src/main/kotlin/jces1209/vu/page/JiraCloudProjectList.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/page/JiraCloudProjectList.kt
@@ -1,12 +1,9 @@
 package jces1209.vu.page
 
 import com.atlassian.performance.tools.jiraactions.api.memories.Project
-import com.atlassian.performance.tools.jiraactions.api.page.wait
 import org.openqa.selenium.By
 import org.openqa.selenium.WebDriver
 import org.openqa.selenium.WebElement
-import org.openqa.selenium.support.ui.ExpectedConditions.visibilityOfElementLocated
-import java.time.Duration
 
 class JiraCloudProjectList(
     private val driver: WebDriver
@@ -14,14 +11,15 @@ class JiraCloudProjectList(
     private val projectListSelector = By.cssSelector(
         "[data-test-id='global-pages.directories.directory-base.content.table.container']"
     )
+    private val falliblePage = FalliblePage.Builder(
+        expectedContent = listOf(projectListSelector),
+        webDriver = driver
+    )
+        .cloudErrors()
+        .build()
 
-    fun lookForProjects(
-        timeout: Duration
-    ): JiraCloudProjectList {
-        driver.wait(
-            condition = visibilityOfElementLocated(projectListSelector),
-            timeout = timeout
-        )
+    fun lookForProjects(): JiraCloudProjectList {
+        falliblePage.waitForPageToLoad()
         return this
     }
 

--- a/custom-vu/src/main/kotlin/jces1209/vu/page/filters/CloudFiltersPage.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/page/filters/CloudFiltersPage.kt
@@ -1,10 +1,9 @@
 package jces1209.vu.page.filters
 
 import com.atlassian.performance.tools.jiraactions.api.WebJira
-import jces1209.vu.wait
+import jces1209.vu.page.FalliblePage
 import org.openqa.selenium.By
 import org.openqa.selenium.WebDriver
-import org.openqa.selenium.support.ui.ExpectedConditions.visibilityOfElementLocated
 
 class CloudFiltersPage(
     private val jira: WebJira,
@@ -12,6 +11,12 @@ class CloudFiltersPage(
 ) : FiltersPage {
 
     private val table = By.cssSelector("[data-test-id='global-pages.directories.directory-base.content.table.container']")
+    private val falliblePage = FalliblePage.Builder(
+        expectedContent = listOf(table),
+        webDriver = driver
+    )
+        .cloudErrors()
+        .build()
 
     override fun open(): FiltersPage {
         jira.navigateTo("secure/ManageFilters.jspa?sortKey=popularity&sortOrder=DESC&filterView=search")
@@ -19,7 +24,7 @@ class CloudFiltersPage(
     }
 
     override fun waitForList(): FiltersList {
-        val element = driver.wait(visibilityOfElementLocated(table))
-        return CloudFiltersList(element)
+        falliblePage.waitForPageToLoad()
+        return CloudFiltersList(driver.findElement(table))
     }
 }

--- a/custom-vu/src/main/kotlin/jces1209/vu/page/filters/ServerFiltersPage.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/page/filters/ServerFiltersPage.kt
@@ -1,10 +1,9 @@
 package jces1209.vu.page.filters
 
 import com.atlassian.performance.tools.jiraactions.api.WebJira
-import jces1209.vu.wait
+import jces1209.vu.page.FalliblePage
 import org.openqa.selenium.By
 import org.openqa.selenium.WebDriver
-import org.openqa.selenium.support.ui.ExpectedConditions.visibilityOfElementLocated
 
 class ServerFiltersPage(
     private val jira: WebJira,
@@ -12,6 +11,12 @@ class ServerFiltersPage(
 ) : FiltersPage {
 
     private val table = By.id("mf_popular")
+    private val falliblePage = FalliblePage.Builder(
+        expectedContent = listOf(table),
+        webDriver = driver
+    )
+        .serverErrors()
+        .build()
 
     override fun open(): FiltersPage {
         jira.navigateTo("secure/ManageFilters.jspa?filterView=popular")
@@ -19,7 +24,7 @@ class ServerFiltersPage(
     }
 
     override fun waitForList(): FiltersList {
-        val element = driver.wait(visibilityOfElementLocated(table))
-        return ServerFiltersList(element)
+        falliblePage.waitForPageToLoad()
+        return ServerFiltersList(driver.findElement(table))
     }
 }


### PR DESCRIPTION
Fallible page now covers most pages that do not use complicated 'and/or' conditions and clickable/interactable elements. 