### PR TITLE
JPERF-2931 Make AwsVus provision nodes with subnetId and vpcId 

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,11 @@ Benchmark two Jiras against each other. Both [Jira Cloud] and [Jira Data Center]
 [AWS credentials]: docs/AWS-CREDENTIALS.md
 [example properties]: cohort-secrets/example.properties
 
+### AWS - Provision nodes to a vpc and subnet
+You specify both vpc and subnet of the nodes provisioned for JPT when using SlowAndMeaningful benchmark quality by 
+providing values for following as env variables:
+* subnetId
+* vpcId  
+
 ### Prior art
 Originally forked from [quick-303](https://github.com/atlassian/quick-303).

--- a/src/test/kotlin/jces1209/SlowAndMeaningful.kt
+++ b/src/test/kotlin/jces1209/SlowAndMeaningful.kt
@@ -15,7 +15,10 @@ class SlowAndMeaningful private constructor(
     private val duration: Duration
 ) : BenchmarkQuality {
 
-    override fun provide(): VirtualUsersSource = AwsVus(duration, region)
+    override fun provide(): VirtualUsersSource = AwsVus(duration, region,
+        System.getenv("vpcId"),
+        System.getenv("subnetId")
+    )
 
     override fun behave(scenario: Class<out Scenario>): VirtualUserBehavior = VirtualUserBehavior.Builder(scenario)
         .browser(browser)


### PR DESCRIPTION
We would like to have the ability to run JPT in bamboo, and provision the nodes in a specific vpc and subnet which is able to access the staging sites.

The changes in this PR will default to what it was doing before if no env var is passed to specify vpcId and subnetId.

See https://jdog.jira-dev.com/browse/JPERF-2931