### PR TITLE
Generate traffic data configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ virtual-users.log
 test-results
 diagnoses
 cloud-session.properties
+BoardUsageFrequency.csv
 .DS_Store

--- a/custom-vu/build.gradle.kts
+++ b/custom-vu/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
     implementation("org.seleniumhq.selenium:selenium-firefox-driver:$seleniumVersion")
     implementation("org.seleniumhq.selenium:selenium-chrome-driver:$seleniumVersion")
     implementation("org.glassfish:javax.json:1.1")
+    implementation("com.google.code.gson:gson:2.8.0")
     implementation(kotlin("stdlib-jdk8"))
 
     testCompile("junit:junit:4.12")
@@ -39,7 +40,7 @@ configurations.all {
         eachDependency {
             when (requested.module.toString()) {
                 "commons-codec:commons-codec" -> useVersion("1.10")
-                "com.google.code.gson:gson" -> useVersion("2.8.2")
+                "com.google.code.gson:gson" -> useVersion("2.8.0")
                 "com.google.guava:guava" -> useVersion("25.0-jre")
                 "org.slf4j:slf4j-api" -> useVersion("1.8.0-alpha2")
             }

--- a/custom-vu/gradle/dependency-locks/compileClasspath.lockfile
+++ b/custom-vu/gradle/dependency-locks/compileClasspath.lockfile
@@ -29,3 +29,4 @@ org.seleniumhq.selenium:selenium-chrome-driver:3.141.59
 org.seleniumhq.selenium:selenium-firefox-driver:3.141.59
 org.seleniumhq.selenium:selenium-remote-driver:3.141.59
 org.seleniumhq.selenium:selenium-support:3.141.59
+com.google.code.gson:gson:2.8.0

--- a/custom-vu/gradle/dependency-locks/default.lockfile
+++ b/custom-vu/gradle/dependency-locks/default.lockfile
@@ -10,7 +10,7 @@ com.atlassian.performance.tools:virtual-users:3.10.0
 com.atlassian.performance:selenium-js:1.0.1
 com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.code.findbugs:jsr305:1.3.9
-com.google.code.gson:gson:2.8.2
+com.google.code.gson:gson:2.8.0
 com.google.errorprone:error_prone_annotations:2.1.3
 com.google.guava:guava:25.0-jre
 com.google.j2objc:j2objc-annotations:1.1

--- a/custom-vu/gradle/dependency-locks/implementationDependenciesMetadata.lockfile
+++ b/custom-vu/gradle/dependency-locks/implementationDependenciesMetadata.lockfile
@@ -10,7 +10,7 @@ com.atlassian.performance.tools:virtual-users:3.10.0
 com.atlassian.performance:selenium-js:1.0.1
 com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.code.findbugs:jsr305:1.3.9
-com.google.code.gson:gson:2.8.2
+com.google.code.gson:gson:2.8.0
 com.google.errorprone:error_prone_annotations:2.1.3
 com.google.guava:guava:25.0-jre
 com.google.j2objc:j2objc-annotations:1.1

--- a/custom-vu/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/custom-vu/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -10,7 +10,7 @@ com.atlassian.performance.tools:virtual-users:3.10.0
 com.atlassian.performance:selenium-js:1.0.1
 com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.code.findbugs:jsr305:1.3.9
-com.google.code.gson:gson:2.8.2
+com.google.code.gson:gson:2.8.0
 com.google.errorprone:error_prone_annotations:2.1.3
 com.google.guava:guava:25.0-jre
 com.google.j2objc:j2objc-annotations:1.1

--- a/custom-vu/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/custom-vu/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -32,3 +32,4 @@ org.seleniumhq.selenium:selenium-chrome-driver:3.141.59
 org.seleniumhq.selenium:selenium-firefox-driver:3.141.59
 org.seleniumhq.selenium:selenium-remote-driver:3.141.59
 org.seleniumhq.selenium:selenium-support:3.141.59
+com.google.code.gson:gson:2.8.0

--- a/custom-vu/gradle/dependency-locks/testImplementationDependenciesMetadata.lockfile
+++ b/custom-vu/gradle/dependency-locks/testImplementationDependenciesMetadata.lockfile
@@ -10,7 +10,7 @@ com.atlassian.performance.tools:virtual-users:3.10.0
 com.atlassian.performance:selenium-js:1.0.1
 com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.code.findbugs:jsr305:1.3.9
-com.google.code.gson:gson:2.8.2
+com.google.code.gson:gson:2.8.0
 com.google.errorprone:error_prone_annotations:2.1.3
 com.google.guava:guava:25.0-jre
 com.google.j2objc:j2objc-annotations:1.1

--- a/custom-vu/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/custom-vu/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -10,7 +10,7 @@ com.atlassian.performance.tools:virtual-users:3.10.0
 com.atlassian.performance:selenium-js:1.0.1
 com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.code.findbugs:jsr305:1.3.9
-com.google.code.gson:gson:2.8.2
+com.google.code.gson:gson:2.8.0
 com.google.errorprone:error_prone_annotations:2.1.3
 com.google.guava:guava:25.0-jre
 com.google.j2objc:j2objc-annotations:1.1

--- a/custom-vu/src/main/kotlin/jces1209/vu/ConfigProperties.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/ConfigProperties.kt
@@ -1,7 +1,7 @@
 package jces1209.vu
 
 import java.io.InputStream
-import java.util.*
+import java.util.Properties
 
 class ConfigProperties {
 

--- a/custom-vu/src/main/kotlin/jces1209/vu/ConfigProperties.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/ConfigProperties.kt
@@ -3,8 +3,7 @@ package jces1209.vu
 import java.io.InputStream
 import java.util.*
 
-class ConfigProperties
-{
+class ConfigProperties {
 
     companion object {
         lateinit var properties: Properties
@@ -18,8 +17,5 @@ class ConfigProperties
             }
             return properties
         }
-
     }
-
-
 }

--- a/custom-vu/src/main/kotlin/jces1209/vu/ConfigProperties.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/ConfigProperties.kt
@@ -1,0 +1,74 @@
+package jces1209.vu
+
+import java.io.InputStream
+import java.util.*
+
+class ConfigProperties(
+    val createIssue: Int,
+    val workAnIssue: Int,
+    val manageProjects: Int,
+    val projectSummary: Int,
+    val browseProjects: Int,
+    val browseBoards: Int,
+    val viewBoard: Int,
+    val workOnDashboard: Int,
+    val workOnSprint: Int,
+    val browseProjectIssues: Int,
+    val workOnBacklog: Int,
+    val workOnSearch: Int,
+    val workOnTopBar: Int,
+    val bulkEdit: Int,
+    val workOnTransition: Int,
+    val workOnWorkflow: Int,
+    val browseWorkflows: Int,
+    val browseFieldScreens: Int,
+    val browseFieldConfigurations: Int,
+    val browseCustomFields: Int,
+    val browseIssueTypes: Int,
+    val browseProjectRoles: Int,
+    val virtualUsers: Int?,
+    val ramp: Long?,
+    val maxOverallLoad: Double?,
+    val nodes: Int?
+) {
+
+    companion object {
+        fun load(resourceName: String?): ConfigProperties {
+            val fileReadStream: InputStream? = this::class.java.getResourceAsStream("/$resourceName")
+            val properties = Properties()
+            fileReadStream.use {
+                properties.load(it)
+
+            }
+            return ConfigProperties(
+                createIssue = properties.getProperty("createIssue").toInt(),
+                workAnIssue = properties.getProperty("workAnIssue").toInt(),
+                manageProjects = properties.getProperty("manageProjects").toInt(),
+                projectSummary = properties.getProperty("projectSummary").toInt(),
+                browseProjects = properties.getProperty("browseProjects").toInt(),
+                browseBoards = properties.getProperty("browseBoards").toInt(),
+                viewBoard = properties.getProperty("viewBoard").toInt(),
+                workOnDashboard = properties.getProperty("workOnDashboard").toInt(),
+                workOnSprint = properties.getProperty("workOnSprint").toInt(),
+                browseProjectIssues = properties.getProperty("browseProjectIssues").toInt(),
+                workOnBacklog = properties.getProperty("workOnBacklog").toInt(),
+                workOnSearch = properties.getProperty("workOnSearch").toInt(),
+                workOnTopBar = properties.getProperty("workOnTopBar").toInt(),
+                bulkEdit = properties.getProperty("bulkEdit").toInt(),
+                workOnTransition = properties.getProperty("workOnTransition").toInt(),
+                workOnWorkflow = properties.getProperty("workOnWorkflow").toInt(),
+                browseWorkflows = properties.getProperty("browseWorkflows").toInt(),
+                browseFieldScreens = properties.getProperty("browseFieldScreens").toInt(),
+                browseFieldConfigurations = properties.getProperty("browseFieldConfigurations").toInt(),
+                browseCustomFields = properties.getProperty("browseCustomFields").toInt(),
+                browseIssueTypes = properties.getProperty("browseIssueTypes").toInt(),
+                browseProjectRoles = properties.getProperty("browseProjectRoles").toInt(),
+                virtualUsers = properties.getProperty("virtualUsers")?.toInt(),
+                maxOverallLoad = properties.getProperty("maxOverallLoad")?.toDouble(),
+                ramp = properties.getProperty("nodes")?.toLong(),
+                nodes = properties.getProperty("nodes")?.toInt()
+            )
+        }
+    }
+
+}

--- a/custom-vu/src/main/kotlin/jces1209/vu/ConfigProperties.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/ConfigProperties.kt
@@ -3,72 +3,23 @@ package jces1209.vu
 import java.io.InputStream
 import java.util.*
 
-class ConfigProperties(
-    val createIssue: Int,
-    val workAnIssue: Int,
-    val manageProjects: Int,
-    val projectSummary: Int,
-    val browseProjects: Int,
-    val browseBoards: Int,
-    val viewBoard: Int,
-    val workOnDashboard: Int,
-    val workOnSprint: Int,
-    val browseProjectIssues: Int,
-    val workOnBacklog: Int,
-    val workOnSearch: Int,
-    val workOnTopBar: Int,
-    val bulkEdit: Int,
-    val workOnTransition: Int,
-    val workOnWorkflow: Int,
-    val browseWorkflows: Int,
-    val browseFieldScreens: Int,
-    val browseFieldConfigurations: Int,
-    val browseCustomFields: Int,
-    val browseIssueTypes: Int,
-    val browseProjectRoles: Int,
-    val virtualUsers: Int?,
-    val ramp: Long?,
-    val maxOverallLoad: Double?,
-    val nodes: Int?
-) {
+class ConfigProperties
+{
 
     companion object {
-        fun load(resourceName: String?): ConfigProperties {
-            val fileReadStream: InputStream? = this::class.java.getResourceAsStream("/$resourceName")
-            val properties = Properties()
-            fileReadStream.use {
-                properties.load(it)
+        lateinit var properties: Properties
 
+        fun load(resourceName: String?): Properties {
+            val fileReadStream: InputStream? = this::class.java.getResourceAsStream("/$resourceName")
+
+            properties = Properties()
+            fileReadStream?.use {
+                properties.load(it)
             }
-            return ConfigProperties(
-                createIssue = properties.getProperty("createIssue").toInt(),
-                workAnIssue = properties.getProperty("workAnIssue").toInt(),
-                manageProjects = properties.getProperty("manageProjects").toInt(),
-                projectSummary = properties.getProperty("projectSummary").toInt(),
-                browseProjects = properties.getProperty("browseProjects").toInt(),
-                browseBoards = properties.getProperty("browseBoards").toInt(),
-                viewBoard = properties.getProperty("viewBoard").toInt(),
-                workOnDashboard = properties.getProperty("workOnDashboard").toInt(),
-                workOnSprint = properties.getProperty("workOnSprint").toInt(),
-                browseProjectIssues = properties.getProperty("browseProjectIssues").toInt(),
-                workOnBacklog = properties.getProperty("workOnBacklog").toInt(),
-                workOnSearch = properties.getProperty("workOnSearch").toInt(),
-                workOnTopBar = properties.getProperty("workOnTopBar").toInt(),
-                bulkEdit = properties.getProperty("bulkEdit").toInt(),
-                workOnTransition = properties.getProperty("workOnTransition").toInt(),
-                workOnWorkflow = properties.getProperty("workOnWorkflow").toInt(),
-                browseWorkflows = properties.getProperty("browseWorkflows").toInt(),
-                browseFieldScreens = properties.getProperty("browseFieldScreens").toInt(),
-                browseFieldConfigurations = properties.getProperty("browseFieldConfigurations").toInt(),
-                browseCustomFields = properties.getProperty("browseCustomFields").toInt(),
-                browseIssueTypes = properties.getProperty("browseIssueTypes").toInt(),
-                browseProjectRoles = properties.getProperty("browseProjectRoles").toInt(),
-                virtualUsers = properties.getProperty("virtualUsers")?.toInt(),
-                maxOverallLoad = properties.getProperty("maxOverallLoad")?.toDouble(),
-                ramp = properties.getProperty("nodes")?.toLong(),
-                nodes = properties.getProperty("nodes")?.toInt()
-            )
+            return properties
         }
+
     }
+
 
 }

--- a/custom-vu/src/main/kotlin/jces1209/vu/JiraCloudScenario.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/JiraCloudScenario.kt
@@ -27,6 +27,7 @@ import jces1209.vu.page.admin.manageprojects.CloudManageProjectsPage
 import jces1209.vu.page.admin.projectroles.CloudBrowseProjectRolesPage
 import jces1209.vu.page.admin.workflow.browse.CloudBrowseWorkflowsPage
 import jces1209.vu.page.bars.side.CloudSideBar
+import jces1209.vu.page.bars.topBar.cloud.CloudTopBar
 import jces1209.vu.page.bars.topBar.dc.DcTopBar
 import jces1209.vu.page.boards.browse.cloud.CloudBrowseBoardsPage
 import jces1209.vu.page.customizecolumns.CloudColumnsEditor
@@ -86,7 +87,7 @@ class JiraCloudScenario : Scenario {
             ),
             issueNavigator = CloudIssueNavigator(jira),
             columnsEditor = CloudColumnsEditor(jira.driver),
-            topBar = DcTopBar(jira.driver),
+            topBar = CloudTopBar(jira.driver),
             browseIssueTypesPage = CloudBrowseIssueTypesPage(jira),
             browseProjectRolesPage = CloudBrowseProjectRolesPage(jira),
             sideBar = CloudSideBar(jira)

--- a/custom-vu/src/main/kotlin/jces1209/vu/JiraCloudScenario.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/JiraCloudScenario.kt
@@ -53,6 +53,11 @@ class JiraCloudScenario : Scenario {
 
         val similarities = ScenarioSimilarities(jira, seededRandom, meter)
         return similarities.assembleScenario(
+            createIssue = CreateAnIssue(
+                jira = jira,
+                meter = meter,
+                createIssueButtons = listOf(By.id("createGlobalItem"), By.id("createGlobalItemIconButton"))
+            ),
             issuePage = CloudIssuePage(jira.driver),
             filtersPage = CloudFiltersPage(jira, jira.driver),
             browseFieldScreensPage = CloudBrowseFieldScreensPage(jira),
@@ -62,12 +67,6 @@ class JiraCloudScenario : Scenario {
             dashboardPage = CloudDashboardPage(jira),
             manageProjectsPage = CloudManageProjectsPage(jira),
             projectNavigatorPage = CloudProjectNavigatorPage(jira),
-            createIssue = CreateAnIssue(
-                jira = jira,
-                meter = meter,
-                projectMemory = similarities.projectMemory,
-                createIssueButtons = listOf(By.id("createGlobalItem"), By.id("createGlobalItemIconButton"))
-            ),
             browseProjects = BrowseCloudProjects(
                 jira = jira,
                 meter = meter,

--- a/custom-vu/src/main/kotlin/jces1209/vu/JiraCloudScenario.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/JiraCloudScenario.kt
@@ -94,4 +94,3 @@ class JiraCloudScenario : Scenario {
         )
     }
 }
-

--- a/custom-vu/src/main/kotlin/jces1209/vu/JiraCloudScenario.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/JiraCloudScenario.kt
@@ -1,5 +1,6 @@
 package jces1209.vu
 
+import CloudTopBar
 import com.atlassian.performance.tools.jiraactions.api.SeededRandom
 import com.atlassian.performance.tools.jiraactions.api.WebJira
 import com.atlassian.performance.tools.jiraactions.api.action.Action
@@ -9,16 +10,9 @@ import com.atlassian.performance.tools.jiraactions.api.scenario.Scenario
 import jces1209.vu.action.BrowseCloudProjects
 import jces1209.vu.action.CreateAnIssue
 import jces1209.vu.action.LogInWithAtlassianId
-<<<<<<< HEAD
-import jces1209.vu.page.issuenavigator.CloudIssueNavigator
-=======
 import jces1209.vu.api.dashboard.CloudDashboardApi
 import jces1209.vu.api.issue.CloudIssueApi
-<<<<<<< HEAD
->>>>>>> 444dcad... JCSP-553: dashboard clean up (#101)
-=======
 import jces1209.vu.api.sprint.CloudSprintApi
->>>>>>> dc9f1a4... JSPC-533: sprints clean up (#102)
 import jces1209.vu.page.CloudIssuePage
 import jces1209.vu.page.admin.customfields.CloudBrowseCustomFieldsPage
 import jces1209.vu.page.admin.fieldscreen.CloudBrowseFieldScreensPage
@@ -27,7 +21,6 @@ import jces1209.vu.page.admin.manageprojects.CloudManageProjectsPage
 import jces1209.vu.page.admin.projectroles.CloudBrowseProjectRolesPage
 import jces1209.vu.page.admin.workflow.browse.CloudBrowseWorkflowsPage
 import jces1209.vu.page.bars.side.CloudSideBar
-import jces1209.vu.page.bars.topBar.cloud.CloudTopBar
 import jces1209.vu.page.bars.topBar.dc.DcTopBar
 import jces1209.vu.page.boards.browse.cloud.CloudBrowseBoardsPage
 import jces1209.vu.page.customizecolumns.CloudColumnsEditor
@@ -64,11 +57,6 @@ class JiraCloudScenario : Scenario {
 
         val similarities = ScenarioSimilarities(jira, seededRandom, meter)
         return similarities.assembleScenario(
-            createIssue = CreateAnIssue(
-                jira = jira,
-                meter = meter,
-                createIssueButtons = listOf(By.id("createGlobalItem"), By.id("createGlobalItemIconButton"))
-            ),
             issuePage = CloudIssuePage(jira.driver),
             filtersPage = CloudFiltersPage(jira, jira.driver),
             browseFieldScreensPage = CloudBrowseFieldScreensPage(jira),
@@ -80,6 +68,13 @@ class JiraCloudScenario : Scenario {
             sprintApi = CloudSprintApi(jira.base),
             manageProjectsPage = CloudManageProjectsPage(jira),
             projectNavigatorPage = CloudProjectNavigatorPage(jira),
+            createIssue = CreateAnIssue(
+                jira = jira,
+                meter = meter,
+                projectMemory = similarities.projectMemory,
+                issueApi = CloudIssueApi(jira.base),
+                createIssueButtons = listOf(By.id("createGlobalItem"), By.id("createGlobalItemIconButton"))
+            ),
             browseProjects = BrowseCloudProjects(
                 jira = jira,
                 meter = meter,

--- a/custom-vu/src/main/kotlin/jces1209/vu/JiraCloudScenario.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/JiraCloudScenario.kt
@@ -14,7 +14,11 @@ import jces1209.vu.page.issuenavigator.CloudIssueNavigator
 =======
 import jces1209.vu.api.dashboard.CloudDashboardApi
 import jces1209.vu.api.issue.CloudIssueApi
+<<<<<<< HEAD
 >>>>>>> 444dcad... JCSP-553: dashboard clean up (#101)
+=======
+import jces1209.vu.api.sprint.CloudSprintApi
+>>>>>>> dc9f1a4... JSPC-533: sprints clean up (#102)
 import jces1209.vu.page.CloudIssuePage
 import jces1209.vu.page.admin.customfields.CloudBrowseCustomFieldsPage
 import jces1209.vu.page.admin.fieldscreen.CloudBrowseFieldScreensPage
@@ -72,6 +76,7 @@ class JiraCloudScenario : Scenario {
             browseBoardsPage = CloudBrowseBoardsPage(jira),
             dashboardPage = CloudDashboardPage(jira),
             dashboardApi = CloudDashboardApi(jira.base),
+            sprintApi = CloudSprintApi(jira.base),
             manageProjectsPage = CloudManageProjectsPage(jira),
             projectNavigatorPage = CloudProjectNavigatorPage(jira),
             browseProjects = BrowseCloudProjects(

--- a/custom-vu/src/main/kotlin/jces1209/vu/JiraCloudScenario.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/JiraCloudScenario.kt
@@ -9,13 +9,18 @@ import com.atlassian.performance.tools.jiraactions.api.scenario.Scenario
 import jces1209.vu.action.BrowseCloudProjects
 import jces1209.vu.action.CreateAnIssue
 import jces1209.vu.action.LogInWithAtlassianId
+<<<<<<< HEAD
 import jces1209.vu.page.issuenavigator.CloudIssueNavigator
+=======
+import jces1209.vu.api.dashboard.CloudDashboardApi
+import jces1209.vu.api.issue.CloudIssueApi
+>>>>>>> 444dcad... JCSP-553: dashboard clean up (#101)
 import jces1209.vu.page.CloudIssuePage
-import jces1209.vu.page.admin.projectroles.CloudBrowseProjectRolesPage
 import jces1209.vu.page.admin.customfields.CloudBrowseCustomFieldsPage
 import jces1209.vu.page.admin.fieldscreen.CloudBrowseFieldScreensPage
 import jces1209.vu.page.admin.issuetypes.CloudBrowseIssueTypesPage
 import jces1209.vu.page.admin.manageprojects.CloudManageProjectsPage
+import jces1209.vu.page.admin.projectroles.CloudBrowseProjectRolesPage
 import jces1209.vu.page.admin.workflow.browse.CloudBrowseWorkflowsPage
 import jces1209.vu.page.bars.side.CloudSideBar
 import jces1209.vu.page.bars.topBar.dc.DcTopBar
@@ -23,6 +28,7 @@ import jces1209.vu.page.boards.browse.cloud.CloudBrowseBoardsPage
 import jces1209.vu.page.customizecolumns.CloudColumnsEditor
 import jces1209.vu.page.dashboard.cloud.CloudDashboardPage
 import jces1209.vu.page.filters.CloudFiltersPage
+import jces1209.vu.page.issuenavigator.CloudIssueNavigator
 import jces1209.vu.page.project.CloudProjectNavigatorPage
 import org.openqa.selenium.By
 import org.openqa.selenium.TakesScreenshot
@@ -65,6 +71,7 @@ class JiraCloudScenario : Scenario {
             browseCustomFieldsPage = CloudBrowseCustomFieldsPage(jira),
             browseBoardsPage = CloudBrowseBoardsPage(jira),
             dashboardPage = CloudDashboardPage(jira),
+            dashboardApi = CloudDashboardApi(jira.base),
             manageProjectsPage = CloudManageProjectsPage(jira),
             projectNavigatorPage = CloudProjectNavigatorPage(jira),
             browseProjects = BrowseCloudProjects(

--- a/custom-vu/src/main/kotlin/jces1209/vu/JiraDcScenario.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/JiraDcScenario.kt
@@ -9,22 +9,15 @@ import com.atlassian.performance.tools.jiraactions.api.memories.UserMemory
 import com.atlassian.performance.tools.jiraactions.api.scenario.Scenario
 import jces1209.vu.action.CreateAnIssue
 import jces1209.vu.action.LogInToDc
-<<<<<<< HEAD
-import jces1209.vu.page.issuenavigator.DcIssueNavigator
-=======
 import jces1209.vu.api.dashboard.DcDashboardApi
 import jces1209.vu.api.issue.DcIssueApi
-<<<<<<< HEAD
->>>>>>> 444dcad... JCSP-553: dashboard clean up (#101)
-=======
 import jces1209.vu.api.sprint.DcSprintApi
->>>>>>> dc9f1a4... JSPC-533: sprints clean up (#102)
 import jces1209.vu.page.DcIssuePage
-import jces1209.vu.page.admin.projectroles.DcBrowseProjectRolesPage
 import jces1209.vu.page.admin.customfields.DcBrowseCustomFieldsPage
 import jces1209.vu.page.admin.fieldscreen.DcBrowseFieldScreensPage
 import jces1209.vu.page.admin.issuetypes.DcBrowseIssueTypesPage
 import jces1209.vu.page.admin.manageprojects.DcManageProjectsPage
+import jces1209.vu.page.admin.projectroles.DcBrowseProjectRolesPage
 import jces1209.vu.page.admin.workflow.browse.DcBrowseWorkflowsPage
 import jces1209.vu.page.bars.side.DcSideBar
 import jces1209.vu.page.bars.topBar.dc.DcTopBar
@@ -32,6 +25,7 @@ import jces1209.vu.page.boards.browse.dc.DcBrowseBoardsPage
 import jces1209.vu.page.customizecolumns.DcColumnsEditor
 import jces1209.vu.page.dashboard.dc.DcDashboardPage
 import jces1209.vu.page.filters.ServerFiltersPage
+import jces1209.vu.page.issuenavigator.DcIssueNavigator
 import jces1209.vu.page.project.DcProjectNavigatorPage
 import org.openqa.selenium.By
 import org.openqa.selenium.TakesScreenshot
@@ -73,6 +67,8 @@ class JiraDcScenario : Scenario {
             createIssue = CreateAnIssue(
                 jira = jira,
                 meter = meter,
+                projectMemory = similarities.projectMemory,
+                issueApi = DcIssueApi(jira.base),
                 createIssueButtons = listOf(By.id("create_link"))
             ),
             browseProjects = BrowseProjectsAction(

--- a/custom-vu/src/main/kotlin/jces1209/vu/JiraDcScenario.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/JiraDcScenario.kt
@@ -62,7 +62,6 @@ class JiraDcScenario : Scenario {
             createIssue = CreateAnIssue(
                 jira = jira,
                 meter = meter,
-                projectMemory = similarities.projectMemory,
                 createIssueButtons = listOf(By.id("create_link"))
             ),
             browseProjects = BrowseProjectsAction(

--- a/custom-vu/src/main/kotlin/jces1209/vu/JiraDcScenario.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/JiraDcScenario.kt
@@ -9,7 +9,12 @@ import com.atlassian.performance.tools.jiraactions.api.memories.UserMemory
 import com.atlassian.performance.tools.jiraactions.api.scenario.Scenario
 import jces1209.vu.action.CreateAnIssue
 import jces1209.vu.action.LogInToDc
+<<<<<<< HEAD
 import jces1209.vu.page.issuenavigator.DcIssueNavigator
+=======
+import jces1209.vu.api.dashboard.DcDashboardApi
+import jces1209.vu.api.issue.DcIssueApi
+>>>>>>> 444dcad... JCSP-553: dashboard clean up (#101)
 import jces1209.vu.page.DcIssuePage
 import jces1209.vu.page.admin.projectroles.DcBrowseProjectRolesPage
 import jces1209.vu.page.admin.customfields.DcBrowseCustomFieldsPage
@@ -57,6 +62,7 @@ class JiraDcScenario : Scenario {
             browseCustomFieldsPage = DcBrowseCustomFieldsPage(jira),
             browseBoardsPage = DcBrowseBoardsPage(jira),
             dashboardPage = DcDashboardPage(jira),
+            dashboardApi = DcDashboardApi(jira.base),
             manageProjectsPage = DcManageProjectsPage(jira),
             projectNavigatorPage = DcProjectNavigatorPage(jira),
             createIssue = CreateAnIssue(

--- a/custom-vu/src/main/kotlin/jces1209/vu/JiraDcScenario.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/JiraDcScenario.kt
@@ -14,7 +14,11 @@ import jces1209.vu.page.issuenavigator.DcIssueNavigator
 =======
 import jces1209.vu.api.dashboard.DcDashboardApi
 import jces1209.vu.api.issue.DcIssueApi
+<<<<<<< HEAD
 >>>>>>> 444dcad... JCSP-553: dashboard clean up (#101)
+=======
+import jces1209.vu.api.sprint.DcSprintApi
+>>>>>>> dc9f1a4... JSPC-533: sprints clean up (#102)
 import jces1209.vu.page.DcIssuePage
 import jces1209.vu.page.admin.projectroles.DcBrowseProjectRolesPage
 import jces1209.vu.page.admin.customfields.DcBrowseCustomFieldsPage
@@ -63,6 +67,7 @@ class JiraDcScenario : Scenario {
             browseBoardsPage = DcBrowseBoardsPage(jira),
             dashboardPage = DcDashboardPage(jira),
             dashboardApi = DcDashboardApi(jira.base),
+            sprintApi = DcSprintApi(jira.base),
             manageProjectsPage = DcManageProjectsPage(jira),
             projectNavigatorPage = DcProjectNavigatorPage(jira),
             createIssue = CreateAnIssue(

--- a/custom-vu/src/main/kotlin/jces1209/vu/MeasureType.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/MeasureType.kt
@@ -154,6 +154,9 @@ class MeasureType {
         var TOP_BAR_QUICK_SEARCH = ActionType("Quick search top bar") { Unit }
 
         @JvmField
+        var TOP_BAR_QUICK_SEARCH_SELECT_ITEM = ActionType("Quick search top bar (Select Item)") { Unit }
+
+        @JvmField
         val TRANSITION = ActionType("Transition") { Unit }
 
         @JvmField

--- a/custom-vu/src/main/kotlin/jces1209/vu/ScenarioSimilarities.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/ScenarioSimilarities.kt
@@ -221,8 +221,8 @@ class ScenarioSimilarities(
         val readTrafficShapeConfig = System.getenv("readTrafficShapeConfig")
         var properties = Properties()
 
-        if(!readTrafficShapeConfig.isNullOrEmpty()){
-            val resourceName = TrafficDataParser.parseData(jira.base.host,readTrafficShapeConfig)
+        if (!readTrafficShapeConfig.isNullOrEmpty()) {
+            val resourceName = TrafficDataParser.parseData(jira.base.host, readTrafficShapeConfig)
             properties = ConfigProperties.load(resourceName)
         }
 
@@ -238,7 +238,8 @@ class ScenarioSimilarities(
             workOnDashboard to ((properties.getProperty("action.workOnDashboard")?.toInt()) ?: 5),
             workOnSprint to ((properties.getProperty("action.workOnSprint")?.toInt()) ?: 0), // 3 if we can mutate data
             browseProjectIssues to ((properties.getProperty("action.browseProjectIssues")?.toInt()) ?: 5),
-            workOnBacklog to ((properties.getProperty("action.workOnBacklog")?.toInt()) ?: 0), // 3 if we can mutate data
+            workOnBacklog to ((properties.getProperty("action.workOnBacklog")?.toInt())
+                ?: 0), // 3 if we can mutate data
             workOnSearch to ((properties.getProperty("action.workOnSearch")?.toInt()) ?: 5),
             workOnTopBar to ((properties.getProperty("action.workOnTopBar")?.toInt()) ?: 5),
             bulkEdit to ((properties.getProperty("action.bulkEdit")?.toInt()) ?: 0), // 5 if we can mutate data
@@ -254,8 +255,5 @@ class ScenarioSimilarities(
             .flatten()
             .shuffled(seededRandom.random)
         return exploreData + spreadOut
-
-
-
     }
 }

--- a/custom-vu/src/main/kotlin/jces1209/vu/ScenarioSimilarities.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/ScenarioSimilarities.kt
@@ -144,7 +144,8 @@ class ScenarioSimilarities(
         workOnTopBar = WorkOnTopBar(
             topBar = topBar,
             jira = jira,
-            meter = meter
+            meter = meter,
+            issueKeyMemory = issueKeyMemory
         ),
         workOnSearch = WorkOnSearch(
             issueNavigator = issueNavigator,

--- a/custom-vu/src/main/kotlin/jces1209/vu/ScenarioSimilarities.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/ScenarioSimilarities.kt
@@ -83,7 +83,6 @@ class ScenarioSimilarities(
             jira = jira,
             measure = measure,
             issueKeyMemory = issueKeyMemory,
-            seededRandom = seededRandom,
             editProbability = 0.00f, // 0.10f if we can mutate data
             commentProbability = 0.00f, // 0.04f if we can mutate data
             linkIssueProbability = 0.00f, // 0.10f if we can mutate data

--- a/custom-vu/src/main/kotlin/jces1209/vu/ScenarioSimilarities.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/ScenarioSimilarities.kt
@@ -29,7 +29,7 @@ import jces1209.vu.page.filters.FiltersPage
 import jces1209.vu.page.issuenavigator.IssueNavigator
 import jces1209.vu.page.project.ProjectNavigatorPage
 import java.net.URI
-import java.util.Properties
+import java.util.Collections
 
 class ScenarioSimilarities(
     private val jira: WebJira,

--- a/custom-vu/src/main/kotlin/jces1209/vu/ScenarioSimilarities.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/ScenarioSimilarities.kt
@@ -9,6 +9,7 @@ import com.atlassian.performance.tools.jiraactions.api.memories.adaptive.Adaptiv
 import com.atlassian.performance.tools.jiraactions.api.memories.adaptive.AdaptiveJqlMemory
 import com.atlassian.performance.tools.jiraactions.api.memories.adaptive.AdaptiveProjectMemory
 import jces1209.vu.action.*
+import jces1209.vu.api.dashboard.DashboardApi
 import jces1209.vu.memory.BoardPagesMemory
 import jces1209.vu.memory.SeededMemory
 import jces1209.vu.page.AbstractIssuePage
@@ -53,6 +54,7 @@ class ScenarioSimilarities(
         browseCustomFieldsPage: BrowseCustomFieldsPage,
         browseBoardsPage: BrowseBoardsPage,
         dashboardPage: DashboardPage,
+        dashboardApi: DashboardApi,
         createIssue: Action,
         browseProjects: Action,
         issueNavigator: IssueNavigator,
@@ -74,6 +76,7 @@ class ScenarioSimilarities(
             measure = measure,
             projectKeyMemory = projectMemory,
             dashboardPage = dashboardPage,
+            dashboardApi = dashboardApi,
             viewDashboardsProbability = 1.00f,
             viewDashboardProbability = 1.00f,
             createDashboardAndGadgetProbability = 0.00f // 0.10f if we can mutate data

--- a/custom-vu/src/main/kotlin/jces1209/vu/ScenarioSimilarities.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/ScenarioSimilarities.kt
@@ -10,6 +10,7 @@ import com.atlassian.performance.tools.jiraactions.api.memories.adaptive.Adaptiv
 import com.atlassian.performance.tools.jiraactions.api.memories.adaptive.AdaptiveProjectMemory
 import jces1209.vu.action.*
 import jces1209.vu.api.dashboard.DashboardApi
+import jces1209.vu.api.sprint.SprintApi
 import jces1209.vu.memory.BoardPagesMemory
 import jces1209.vu.memory.SeededMemory
 import jces1209.vu.page.AbstractIssuePage
@@ -55,6 +56,7 @@ class ScenarioSimilarities(
         browseBoardsPage: BrowseBoardsPage,
         dashboardPage: DashboardPage,
         dashboardApi: DashboardApi,
+        sprintApi: SprintApi,
         createIssue: Action,
         browseProjects: Action,
         issueNavigator: IssueNavigator,
@@ -124,6 +126,8 @@ class ScenarioSimilarities(
         ),
         workOnSprint = WorkOnSprint(
             meter = meter,
+            driver = jira.driver,
+            sprintApi = sprintApi,
             backlogsMemory = boardsMemory.backlog,
             sprintsMemory = boardsMemory.sprint,
             jiraTips = JiraTips(jira.driver)

--- a/custom-vu/src/main/kotlin/jces1209/vu/ScenarioSimilarities.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/ScenarioSimilarities.kt
@@ -228,7 +228,7 @@ class ScenarioSimilarities(
             properties = ConfigProperties.load(resourceName)
         }
 
-        val exploreData = listOf(workAnIssue, browseProjects, browseFilters, browseBoards)
+        val exploreData = listOf(createIssue, workAnIssue, browseProjects, browseFilters, browseBoards)
         val spreadOut = mapOf(
             createIssue to ((properties.getProperty("action.createIssue")?.toInt()) ?: 0), // 5 if we can mutate data
             workAnIssue to ((properties.getProperty("action.workAnIssue")?.toInt()) ?: 55),

--- a/custom-vu/src/main/kotlin/jces1209/vu/ScenarioSimilarities.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/ScenarioSimilarities.kt
@@ -227,7 +227,7 @@ class ScenarioSimilarities(
             properties = ConfigProperties.load(resourceName)
         }
 
-        val exploreData = listOf(browseProjects, browseFilters, browseBoards)
+        val exploreData = listOf(browseProjects, browseFilters, browseBoards, workAnIssue)
         val spreadOut = mapOf(
             createIssue to ((properties.getProperty("action.createIssue")?.toInt()) ?: 0), // 5 if we can mutate data
             workAnIssue to ((properties.getProperty("action.workAnIssue")?.toInt()) ?: 55),

--- a/custom-vu/src/main/kotlin/jces1209/vu/ScenarioSimilarities.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/ScenarioSimilarities.kt
@@ -30,6 +30,7 @@ import jces1209.vu.page.issuenavigator.IssueNavigator
 import jces1209.vu.page.project.ProjectNavigatorPage
 import java.net.URI
 import java.util.Collections
+import java.util.Properties
 
 class ScenarioSimilarities(
     private val jira: WebJira,

--- a/custom-vu/src/main/kotlin/jces1209/vu/ScenarioSimilarities.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/ScenarioSimilarities.kt
@@ -29,7 +29,7 @@ import jces1209.vu.page.filters.FiltersPage
 import jces1209.vu.page.issuenavigator.IssueNavigator
 import jces1209.vu.page.project.ProjectNavigatorPage
 import java.net.URI
-import java.util.*
+import java.util.Properties
 
 class ScenarioSimilarities(
     private val jira: WebJira,

--- a/custom-vu/src/main/kotlin/jces1209/vu/ScenarioSimilarities.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/ScenarioSimilarities.kt
@@ -83,6 +83,7 @@ class ScenarioSimilarities(
             jira = jira,
             measure = measure,
             issueKeyMemory = issueKeyMemory,
+            seededRandom = seededRandom,
             editProbability = 0.00f, // 0.10f if we can mutate data
             commentProbability = 0.00f, // 0.04f if we can mutate data
             linkIssueProbability = 0.00f, // 0.10f if we can mutate data
@@ -227,7 +228,7 @@ class ScenarioSimilarities(
             properties = ConfigProperties.load(resourceName)
         }
 
-        val exploreData = listOf(browseProjects, browseFilters, browseBoards, workAnIssue)
+        val exploreData = listOf(workAnIssue, browseProjects, browseFilters, browseBoards)
         val spreadOut = mapOf(
             createIssue to ((properties.getProperty("action.createIssue")?.toInt()) ?: 0), // 5 if we can mutate data
             workAnIssue to ((properties.getProperty("action.workAnIssue")?.toInt()) ?: 55),

--- a/custom-vu/src/main/kotlin/jces1209/vu/ScenarioSimilarities.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/ScenarioSimilarities.kt
@@ -228,27 +228,27 @@ class ScenarioSimilarities(
 
         val exploreData = listOf(browseProjects, browseFilters, browseBoards)
         val spreadOut = mapOf(
-            createIssue to ((properties.getProperty("createIssue")?.toInt()) ?: 0), // 5 if we can mutate data
-            workAnIssue to ((properties.getProperty("workAnIssue")?.toInt()) ?: 55),
-            manageProjects to ((properties.getProperty("manageProjects")?.toInt()) ?: 5),
-            projectSummary to ((properties.getProperty("projectSummary")?.toInt()) ?: 5),
-            browseProjects to ((properties.getProperty("browseProjects")?.toInt()) ?: 5),
-            browseBoards to ((properties.getProperty("browseBoards")?.toInt()) ?: 5),
-            viewBoard to ((properties.getProperty("viewBoard")?.toInt()) ?: 30),
-            workOnDashboard to ((properties.getProperty("workOnDashboard")?.toInt()) ?: 5),
-            workOnSprint to ((properties.getProperty("workOnSprint")?.toInt()) ?: 0), // 3 if we can mutate data
-            browseProjectIssues to ((properties.getProperty("browseProjectIssues")?.toInt()) ?: 5),
-            workOnBacklog to ((properties.getProperty("workOnBacklog")?.toInt()) ?: 0), // 3 if we can mutate data
-            workOnSearch to ((properties.getProperty("workOnSearch")?.toInt()) ?: 5),
-            workOnTopBar to ((properties.getProperty("workOnTopBar")?.toInt()) ?: 5),
-            bulkEdit to ((properties.getProperty("bulkEdit")?.toInt()) ?: 0), // 5 if we can mutate data
-            workOnTransition to ((properties.getProperty("workOnTransition")?.toInt()) ?: 5),
-            workOnWorkflow to ((properties.getProperty("workOnWorkflow")?.toInt()) ?: 5),
-            browseFieldScreens to ((properties.getProperty("browseFieldScreens")?.toInt()) ?: 5),
-            browseFieldConfigurations to ((properties.getProperty("browseFieldConfigurations")?.toInt()) ?: 5),
-            browseCustomFields to ((properties.getProperty("browseCustomFields")?.toInt()) ?: 5),
-            browseIssueTypes to ((properties.getProperty("browseIssueTypes")?.toInt()) ?: 5),
-            browseProjectRoles to ((properties.getProperty("browseProjectRoles")?.toInt()) ?: 5)
+            createIssue to ((properties.getProperty("action.createIssue")?.toInt()) ?: 0), // 5 if we can mutate data
+            workAnIssue to ((properties.getProperty("action.workAnIssue")?.toInt()) ?: 55),
+            manageProjects to ((properties.getProperty("action.manageProjects")?.toInt()) ?: 5),
+            projectSummary to ((properties.getProperty("action.projectSummary")?.toInt()) ?: 5),
+            browseProjects to ((properties.getProperty("action.browseProjects")?.toInt()) ?: 5),
+            browseBoards to ((properties.getProperty("action.browseBoards")?.toInt()) ?: 5),
+            viewBoard to ((properties.getProperty("action.viewBoard")?.toInt()) ?: 30),
+            workOnDashboard to ((properties.getProperty("action.workOnDashboard")?.toInt()) ?: 5),
+            workOnSprint to ((properties.getProperty("action.workOnSprint")?.toInt()) ?: 0), // 3 if we can mutate data
+            browseProjectIssues to ((properties.getProperty("action.browseProjectIssues")?.toInt()) ?: 5),
+            workOnBacklog to ((properties.getProperty("action.workOnBacklog")?.toInt()) ?: 0), // 3 if we can mutate data
+            workOnSearch to ((properties.getProperty("action.workOnSearch")?.toInt()) ?: 5),
+            workOnTopBar to ((properties.getProperty("action.workOnTopBar")?.toInt()) ?: 5),
+            bulkEdit to ((properties.getProperty("action.bulkEdit")?.toInt()) ?: 0), // 5 if we can mutate data
+            workOnTransition to ((properties.getProperty("action.workOnTransition")?.toInt()) ?: 5),
+            workOnWorkflow to ((properties.getProperty("action.workOnWorkflow")?.toInt()) ?: 5),
+            browseFieldScreens to ((properties.getProperty("action.browseFieldScreens")?.toInt()) ?: 5),
+            browseFieldConfigurations to ((properties.getProperty("action.browseFieldConfigurations")?.toInt()) ?: 5),
+            browseCustomFields to ((properties.getProperty("action.browseCustomFields")?.toInt()) ?: 5),
+            browseIssueTypes to ((properties.getProperty("action.browseIssueTypes")?.toInt()) ?: 5),
+            browseProjectRoles to ((properties.getProperty("action.browseProjectRoles")?.toInt()) ?: 5)
         )
             .map { (action, proportion) -> Collections.nCopies(proportion, action) }
             .flatten()

--- a/custom-vu/src/main/kotlin/jces1209/vu/ScenarioSimilarities.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/ScenarioSimilarities.kt
@@ -219,75 +219,43 @@ class ScenarioSimilarities(
         browseProjectRoles: Action
     ): List<Action> {
         val readTrafficShapeConfig = System.getenv("readTrafficShapeConfig")
+        var properties = Properties()
 
-        if (readTrafficShapeConfig.isNullOrEmpty()) {
-            val exploreData = listOf(browseProjects, browseFilters, browseBoards)
-            val spreadOut = mapOf(
-                createIssue to 0, // 5 if we can mutate data
-                workAnIssue to 55,
-                manageProjects to 5,
-                projectSummary to 5,
-                browseProjects to 5,
-                browseBoards to 5,
-                viewBoard to 30,
-                workOnDashboard to 5,
-                workOnSprint to 0, // 3 if we can mutate data
-                browseProjectIssues to 5,
-                workOnBacklog to 0, // 3 if we can mutate data
-                workOnSearch to 5,
-                workOnTopBar to 5,
-                bulkEdit to 0, // 5 if we can mutate data
-                workOnTransition to 5,
-                workOnWorkflow to 5,
-                browseFieldScreens to 5,
-                browseFieldConfigurations to 5,
-                browseCustomFields to 5,
-                browseIssueTypes to 5,
-                browseProjectRoles to 5
-            )
-
-                .map { (action, proportion) -> Collections.nCopies(proportion, action) }
-                .flatten()
-                .shuffled(seededRandom.random)
-
-            return exploreData + spreadOut
-
-        } else {
-
-            val resourceName = TrafficDataParser.parseData(jira.base.host, readTrafficShapeConfig)
-            val properties = ConfigProperties.load(resourceName)
-            val exploreData = listOf(browseProjects, browseFilters, browseBoards)
-            val spreadOut = mapOf(
-                createIssue to properties.createIssue, // 5 if we can mutate data
-                workAnIssue to properties.workAnIssue,
-                manageProjects to properties.manageProjects,
-                projectSummary to properties.projectSummary,
-                browseProjects to properties.browseProjects,
-                browseBoards to properties.browseBoards,
-                viewBoard to properties.viewBoard,
-                workOnDashboard to properties.workOnDashboard,
-                workOnSprint to properties.workOnSprint, // 3 if we can mutate data
-                browseProjectIssues to properties.browseProjectIssues,
-                workOnBacklog to properties.workOnBacklog, // 3 if we can mutate data
-                workOnSearch to properties.workOnSearch,
-                workOnTopBar to properties.workOnTopBar,
-                bulkEdit to properties.bulkEdit, // 5 if we can mutate data
-                workOnTransition to properties.workOnTransition,
-                workOnWorkflow to properties.workOnWorkflow,
-                browseFieldScreens to properties.browseFieldScreens,
-                browseFieldConfigurations to properties.browseFieldConfigurations,
-                browseCustomFields to properties.browseCustomFields,
-                browseIssueTypes to properties.browseIssueTypes,
-                browseProjectRoles to properties.browseProjectRoles
-            )
-
-                .map { (action, proportion) -> Collections.nCopies(proportion, action) }
-                .flatten()
-                .shuffled(seededRandom.random)
-
-            return exploreData + spreadOut
-
-
+        if(!readTrafficShapeConfig.isNullOrEmpty()){
+            val resourceName = TrafficDataParser.parseData(jira.base.host,readTrafficShapeConfig)
+            properties = ConfigProperties.load(resourceName)
         }
+
+        val exploreData = listOf(browseProjects, browseFilters, browseBoards)
+        val spreadOut = mapOf(
+            createIssue to ((properties.getProperty("createIssue")?.toInt()) ?: 0), // 5 if we can mutate data
+            workAnIssue to ((properties.getProperty("workAnIssue")?.toInt()) ?: 55),
+            manageProjects to ((properties.getProperty("manageProjects")?.toInt()) ?: 5),
+            projectSummary to ((properties.getProperty("projectSummary")?.toInt()) ?: 5),
+            browseProjects to ((properties.getProperty("browseProjects")?.toInt()) ?: 5),
+            browseBoards to ((properties.getProperty("browseBoards")?.toInt()) ?: 5),
+            viewBoard to ((properties.getProperty("viewBoard")?.toInt()) ?: 30),
+            workOnDashboard to ((properties.getProperty("workOnDashboard")?.toInt()) ?: 5),
+            workOnSprint to ((properties.getProperty("workOnSprint")?.toInt()) ?: 0), // 3 if we can mutate data
+            browseProjectIssues to ((properties.getProperty("browseProjectIssues")?.toInt()) ?: 5),
+            workOnBacklog to ((properties.getProperty("workOnBacklog")?.toInt()) ?: 0), // 3 if we can mutate data
+            workOnSearch to ((properties.getProperty("workOnSearch")?.toInt()) ?: 5),
+            workOnTopBar to ((properties.getProperty("workOnTopBar")?.toInt()) ?: 5),
+            bulkEdit to ((properties.getProperty("bulkEdit")?.toInt()) ?: 0), // 5 if we can mutate data
+            workOnTransition to ((properties.getProperty("workOnTransition")?.toInt()) ?: 5),
+            workOnWorkflow to ((properties.getProperty("workOnWorkflow")?.toInt()) ?: 5),
+            browseFieldScreens to ((properties.getProperty("browseFieldScreens")?.toInt()) ?: 5),
+            browseFieldConfigurations to ((properties.getProperty("browseFieldConfigurations")?.toInt()) ?: 5),
+            browseCustomFields to ((properties.getProperty("browseCustomFields")?.toInt()) ?: 5),
+            browseIssueTypes to ((properties.getProperty("browseIssueTypes")?.toInt()) ?: 5),
+            browseProjectRoles to ((properties.getProperty("browseProjectRoles")?.toInt()) ?: 5)
+        )
+            .map { (action, proportion) -> Collections.nCopies(proportion, action) }
+            .flatten()
+            .shuffled(seededRandom.random)
+        return exploreData + spreadOut
+
+
+
     }
 }

--- a/custom-vu/src/main/kotlin/jces1209/vu/ScenarioSimilarities.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/ScenarioSimilarities.kt
@@ -218,33 +218,76 @@ class ScenarioSimilarities(
         browseIssueTypes: Action,
         browseProjectRoles: Action
     ): List<Action> {
-        val exploreData = listOf(browseProjects, browseFilters, browseBoards)
-        val spreadOut = mapOf(
-            createIssue to 0, // 5 if we can mutate data
-            workAnIssue to 55,
-            manageProjects to 5,
-            projectSummary to 5,
-            browseProjects to 5,
-            browseBoards to 5,
-            viewBoard to 30,
-            workOnDashboard to 5,
-            workOnSprint to 0, // 3 if we can mutate data
-            browseProjectIssues to 5,
-            workOnBacklog to 0, // 3 if we can mutate data
-            workOnSearch to 5,
-            workOnTopBar to 5,
-            bulkEdit to 0, // 5 if we can mutate data
-            workOnTransition to 5,
-            workOnWorkflow to 5,
-            browseFieldScreens to 5,
-            browseFieldConfigurations to 5,
-            browseCustomFields to 5,
-            browseIssueTypes to 5,
-            browseProjectRoles to 5
-        )
-            .map { (action, proportion) -> Collections.nCopies(proportion, action) }
-            .flatten()
-            .shuffled(seededRandom.random)
-        return exploreData + spreadOut
+        val readTrafficShapeConfig = System.getenv("readTrafficShapeConfig")
+
+        if (readTrafficShapeConfig.isNullOrEmpty()) {
+            val exploreData = listOf(browseProjects, browseFilters, browseBoards)
+            val spreadOut = mapOf(
+                createIssue to 0, // 5 if we can mutate data
+                workAnIssue to 55,
+                manageProjects to 5,
+                projectSummary to 5,
+                browseProjects to 5,
+                browseBoards to 5,
+                viewBoard to 30,
+                workOnDashboard to 5,
+                workOnSprint to 0, // 3 if we can mutate data
+                browseProjectIssues to 5,
+                workOnBacklog to 0, // 3 if we can mutate data
+                workOnSearch to 5,
+                workOnTopBar to 5,
+                bulkEdit to 0, // 5 if we can mutate data
+                workOnTransition to 5,
+                workOnWorkflow to 5,
+                browseFieldScreens to 5,
+                browseFieldConfigurations to 5,
+                browseCustomFields to 5,
+                browseIssueTypes to 5,
+                browseProjectRoles to 5
+            )
+
+                .map { (action, proportion) -> Collections.nCopies(proportion, action) }
+                .flatten()
+                .shuffled(seededRandom.random)
+
+            return exploreData + spreadOut
+
+        } else {
+
+            val resourceName = TrafficDataParser.parseData(jira.base.host, readTrafficShapeConfig)
+            val properties = ConfigProperties.load(resourceName)
+            val exploreData = listOf(browseProjects, browseFilters, browseBoards)
+            val spreadOut = mapOf(
+                createIssue to properties.createIssue, // 5 if we can mutate data
+                workAnIssue to properties.workAnIssue,
+                manageProjects to properties.manageProjects,
+                projectSummary to properties.projectSummary,
+                browseProjects to properties.browseProjects,
+                browseBoards to properties.browseBoards,
+                viewBoard to properties.viewBoard,
+                workOnDashboard to properties.workOnDashboard,
+                workOnSprint to properties.workOnSprint, // 3 if we can mutate data
+                browseProjectIssues to properties.browseProjectIssues,
+                workOnBacklog to properties.workOnBacklog, // 3 if we can mutate data
+                workOnSearch to properties.workOnSearch,
+                workOnTopBar to properties.workOnTopBar,
+                bulkEdit to properties.bulkEdit, // 5 if we can mutate data
+                workOnTransition to properties.workOnTransition,
+                workOnWorkflow to properties.workOnWorkflow,
+                browseFieldScreens to properties.browseFieldScreens,
+                browseFieldConfigurations to properties.browseFieldConfigurations,
+                browseCustomFields to properties.browseCustomFields,
+                browseIssueTypes to properties.browseIssueTypes,
+                browseProjectRoles to properties.browseProjectRoles
+            )
+
+                .map { (action, proportion) -> Collections.nCopies(proportion, action) }
+                .flatten()
+                .shuffled(seededRandom.random)
+
+            return exploreData + spreadOut
+
+
+        }
     }
 }

--- a/custom-vu/src/main/kotlin/jces1209/vu/TrafficDataParser.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/TrafficDataParser.kt
@@ -1,7 +1,7 @@
 package jces1209.vu
 
 import java.io.StringReader
-import java.util.*
+import java.util.Base64
 import javax.json.Json
 import javax.json.JsonReader
 
@@ -10,7 +10,6 @@ class TrafficDataParser {
     companion object {
 
         fun parseData(hostName: String, readEnvTrafficShapeConfig: String): String {
-
             val decodedBytes = Base64.getDecoder().decode(readEnvTrafficShapeConfig)
             val decodedString = String(decodedBytes)
             val jsonReader: JsonReader = Json.createReader(StringReader(decodedString))

--- a/custom-vu/src/main/kotlin/jces1209/vu/TrafficDataParser.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/TrafficDataParser.kt
@@ -1,6 +1,7 @@
 package jces1209.vu
 
 import java.io.StringReader
+import java.util.*
 import javax.json.Json
 import javax.json.JsonReader
 
@@ -10,7 +11,9 @@ class TrafficDataParser {
 
         fun parseData(hostName: String, readEnvTrafficShapeConfig: String): String {
 
-            val jsonReader: JsonReader = Json.createReader(StringReader(readEnvTrafficShapeConfig))
+            val decodedBytes = Base64.getDecoder().decode(readEnvTrafficShapeConfig)
+            val decodedString = String(decodedBytes)
+            val jsonReader: JsonReader = Json.createReader(StringReader(decodedString))
             var propertiesFileName = ""
             jsonReader.use {
                 val obj: javax.json.JsonObject = jsonReader.readObject()
@@ -18,7 +21,5 @@ class TrafficDataParser {
             }
             return propertiesFileName
         }
-
-
     }
 }

--- a/custom-vu/src/main/kotlin/jces1209/vu/TrafficDataParser.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/TrafficDataParser.kt
@@ -1,0 +1,22 @@
+package jces1209.vu
+
+import java.io.StringReader
+import javax.json.Json
+import javax.json.JsonReader
+
+class TrafficDataParser {
+
+    companion object {
+
+        fun parseData(hostName: String, readEnvTrafficShapeConfig: String): String {
+
+            val jsonReader: JsonReader = Json.createReader(StringReader(readEnvTrafficShapeConfig))
+            val obj: javax.json.JsonObject = jsonReader.readObject()
+            val propertiesFileName: String = obj.getString(hostName)
+            jsonReader.close()
+            return propertiesFileName
+        }
+
+
+    }
+}

--- a/custom-vu/src/main/kotlin/jces1209/vu/TrafficDataParser.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/TrafficDataParser.kt
@@ -11,9 +11,11 @@ class TrafficDataParser {
         fun parseData(hostName: String, readEnvTrafficShapeConfig: String): String {
 
             val jsonReader: JsonReader = Json.createReader(StringReader(readEnvTrafficShapeConfig))
-            val obj: javax.json.JsonObject = jsonReader.readObject()
-            val propertiesFileName: String = obj.getString(hostName)
-            jsonReader.close()
+            var propertiesFileName = ""
+            jsonReader.use {
+                val obj: javax.json.JsonObject = jsonReader.readObject()
+                propertiesFileName = obj.getString(hostName)
+            }
             return propertiesFileName
         }
 

--- a/custom-vu/src/main/kotlin/jces1209/vu/action/CreateAnIssue.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/action/CreateAnIssue.kt
@@ -5,7 +5,6 @@ import com.atlassian.performance.tools.jiraactions.api.CREATE_ISSUE_SUBMIT
 import com.atlassian.performance.tools.jiraactions.api.WebJira
 import com.atlassian.performance.tools.jiraactions.api.action.Action
 import com.atlassian.performance.tools.jiraactions.api.measure.ActionMeter
-import com.atlassian.performance.tools.jiraactions.api.memories.ProjectMemory
 import com.atlassian.performance.tools.jiraactions.api.page.form.IssueForm
 import com.atlassian.performance.tools.jiraactions.api.page.wait
 import jces1209.vu.MeasureType.Companion.CREATE_ISSUE_MODAL
@@ -19,17 +18,11 @@ import java.time.Duration
 class CreateAnIssue(
     private val jira: WebJira,
     private val meter: ActionMeter,
-    private val projectMemory: ProjectMemory,
     private val createIssueButtons: List<By>
 ) : Action {
     private val logger: Logger = LogManager.getLogger(this::class.java)
 
     override fun run() {
-        val project = projectMemory.recall()
-        if (project == null) {
-            logger.debug("Skipping Create issue action. I have no knowledge of projects.")
-            return
-        }
         meter.measure(CREATE_ISSUE) {
             jira.goToDashboard().dismissAllPopups()
             openDialog().fillRequiredFields() // TODO: to be fair, we should pick a random project and random issue type

--- a/custom-vu/src/main/kotlin/jces1209/vu/action/CreateAnIssue.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/action/CreateAnIssue.kt
@@ -5,9 +5,11 @@ import com.atlassian.performance.tools.jiraactions.api.CREATE_ISSUE_SUBMIT
 import com.atlassian.performance.tools.jiraactions.api.WebJira
 import com.atlassian.performance.tools.jiraactions.api.action.Action
 import com.atlassian.performance.tools.jiraactions.api.measure.ActionMeter
+import com.atlassian.performance.tools.jiraactions.api.memories.ProjectMemory
 import com.atlassian.performance.tools.jiraactions.api.page.form.IssueForm
 import com.atlassian.performance.tools.jiraactions.api.page.wait
 import jces1209.vu.MeasureType.Companion.CREATE_ISSUE_MODAL
+import jces1209.vu.api.issue.IssueApi
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 import org.openqa.selenium.By
@@ -18,23 +20,38 @@ import java.time.Duration
 class CreateAnIssue(
     private val jira: WebJira,
     private val meter: ActionMeter,
+    private val projectMemory: ProjectMemory,
+    private val issueApi: IssueApi,
     private val createIssueButtons: List<By>
 ) : Action {
     private val logger: Logger = LogManager.getLogger(this::class.java)
 
     override fun run() {
-        meter.measure(CREATE_ISSUE) {
-            jira.goToDashboard().dismissAllPopups()
-            openDialog().fillRequiredFields() // TODO: to be fair, we should pick a random project and random issue type
-            meter.measure(CREATE_ISSUE_SUBMIT) {
-                jira.driver.wait(
-                    condition = elementToBeClickable(By.id("create-issue-submit")),
-                    timeout = Duration.ofSeconds(50)
-                ).click()
-                jira.driver.wait(
-                    condition = invisibilityOfElementLocated(By.className("aui-blanket")),
-                    timeout = Duration.ofSeconds(30)
-                )
+        val project = projectMemory.recall()
+        if (project == null) {
+            logger.debug("Skipping Create issue action. I have no knowledge of projects.")
+            return
+        }
+        var issueKey: String? = null
+        try {
+            meter.measure(CREATE_ISSUE) {
+                jira.goToDashboard().dismissAllPopups()
+                openDialog().fillRequiredFields() // TODO: to be fair, we should pick a random project and random issue type
+                meter.measure(CREATE_ISSUE_SUBMIT) {
+                    jira.driver.wait(
+                        condition = elementToBeClickable(By.id("create-issue-submit")),
+                        timeout = Duration.ofSeconds(50)
+                    ).click()
+                    val createdIssueMessage = jira.driver.wait(
+                        condition = visibilityOfElementLocated(By.className("issue-created-key")),
+                        timeout = Duration.ofSeconds(30)
+                    )
+                    issueKey = createdIssueMessage.getAttribute("data-issue-key")
+                }
+            }
+        } finally {
+            if (issueApi.isReady()) {
+                issueKey?.let { issueApi.deleteIssue(it) }
             }
         }
     }
@@ -42,18 +59,18 @@ class CreateAnIssue(
     private fun openDialog(): IssueForm {
         val driver = jira.driver
         meter.measure(CREATE_ISSUE_MODAL) {
-        driver
-            .wait(
-                condition = or(*createIssueButtons.map { elementToBeClickable(it) }.toTypedArray()),
-                timeout = Duration.ofSeconds(10)
-            )
+            driver
+                .wait(
+                    condition = or(*createIssueButtons.map { elementToBeClickable(it) }.toTypedArray()),
+                    timeout = Duration.ofSeconds(10)
+                )
 
-        createIssueButtons
-            .flatMap { driver.findElements(it) }
-            .filter { it.isDisplayed }
-            .first()
-            .click()
-            
+            createIssueButtons
+                .flatMap { driver.findElements(it) }
+                .filter { it.isDisplayed }
+                .first()
+                .click()
+
             driver.wait(
                 condition = visibilityOfElementLocated(By.id("create-issue-dialog")),
                 timeout = Duration.ofSeconds(30)

--- a/custom-vu/src/main/kotlin/jces1209/vu/action/LogInToCloud.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/action/LogInToCloud.kt
@@ -17,7 +17,7 @@ class LogInToCloud(
     override fun run() {
         when (user.domain()) {
             "gmail.com", "atlassian.com" -> LogInWithGoogle(user, jira, meter).run()
-            else -> LogInWithAtlassianId(user, jira, meter).run()
+            else -> LogInWithCookie(jira, meter).run()
         }
     }
 

--- a/custom-vu/src/main/kotlin/jces1209/vu/action/LogInWithAtlassianId.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/action/LogInWithAtlassianId.kt
@@ -39,9 +39,6 @@ class LogInWithAtlassianId(
 
     private fun logIn() {
         jira.goToLogin()
-        if(!System.getenv("readDynamicPropertiesFile").isNullOrEmpty()) {
-            Thread.sleep(Random().nextInt(Duration.ofMinutes(5).toMillis().toInt()).plus(Duration.ofMinutes(5).toMillis()))
-        }
         fillUserName()
         fillPassword()
         chooseAccount()

--- a/custom-vu/src/main/kotlin/jces1209/vu/action/LogInWithAtlassianId.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/action/LogInWithAtlassianId.kt
@@ -11,7 +11,7 @@ import org.openqa.selenium.By
 import org.openqa.selenium.Keys
 import org.openqa.selenium.support.ui.ExpectedConditions.elementToBeClickable
 import java.time.Duration
-import java.util.*
+import java.util.Random
 
 /**
  * Logs in via Atlassian ID.
@@ -39,7 +39,7 @@ class LogInWithAtlassianId(
 
     private fun logIn() {
         jira.goToLogin()
-        Thread.sleep(Random().nextInt(300000)+300000L)
+        Thread.sleep(Random().nextInt(Duration.ofMinutes(5).toMillis().toInt()).plus(Duration.ofMinutes(5).toMillis()))
         fillUserName()
         fillPassword()
         chooseAccount()

--- a/custom-vu/src/main/kotlin/jces1209/vu/action/LogInWithAtlassianId.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/action/LogInWithAtlassianId.kt
@@ -11,6 +11,7 @@ import org.openqa.selenium.By
 import org.openqa.selenium.Keys
 import org.openqa.selenium.support.ui.ExpectedConditions.elementToBeClickable
 import java.time.Duration
+import java.util.*
 
 /**
  * Logs in via Atlassian ID.
@@ -38,6 +39,7 @@ class LogInWithAtlassianId(
 
     private fun logIn() {
         jira.goToLogin()
+        Thread.sleep(Random().nextInt(300000)+300000L)
         fillUserName()
         fillPassword()
         chooseAccount()

--- a/custom-vu/src/main/kotlin/jces1209/vu/action/LogInWithAtlassianId.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/action/LogInWithAtlassianId.kt
@@ -39,7 +39,9 @@ class LogInWithAtlassianId(
 
     private fun logIn() {
         jira.goToLogin()
-        Thread.sleep(Random().nextInt(Duration.ofMinutes(5).toMillis().toInt()).plus(Duration.ofMinutes(5).toMillis()))
+        if(!System.getenv("readDynamicPropertiesFile").isNullOrEmpty()) {
+            Thread.sleep(Random().nextInt(Duration.ofMinutes(5).toMillis().toInt()).plus(Duration.ofMinutes(5).toMillis()))
+        }
         fillUserName()
         fillPassword()
         chooseAccount()

--- a/custom-vu/src/main/kotlin/jces1209/vu/action/WorkOnIssue.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/action/WorkOnIssue.kt
@@ -3,8 +3,6 @@ package jces1209.vu.action
 import com.atlassian.performance.tools.jiraactions.api.*
 import com.atlassian.performance.tools.jiraactions.api.action.Action
 import com.atlassian.performance.tools.jiraactions.api.memories.IssueKeyMemory
-import com.atlassian.performance.tools.jiraactions.api.memories.adaptive.AdaptiveIssueKeyMemory
-import jces1209.vu.ConfigProperties
 import jces1209.vu.Measure
 import jces1209.vu.MeasureType
 import jces1209.vu.MeasureType.Companion.ATTACH_SCREENSHOT
@@ -15,7 +13,6 @@ import jces1209.vu.MeasureType.Companion.ISSUE_LINK_LOAD_FORM
 import jces1209.vu.MeasureType.Companion.ISSUE_LINK_SEARCH_CHOOSE
 import jces1209.vu.MeasureType.Companion.ISSUE_LINK_SUBMIT
 import jces1209.vu.MeasureType.Companion.OPEN_MEDIA_VIEWER
-import jces1209.vu.TrafficDataParser
 import jces1209.vu.page.AbstractIssuePage
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
@@ -27,7 +24,7 @@ class WorkOnIssue(
     private val issuePage: AbstractIssuePage,
     private val jira: WebJira,
     private val measure: Measure,
-    private var issueKeyMemory: IssueKeyMemory,
+    private val issueKeyMemory: IssueKeyMemory,
     private val editProbability: Float,
     private val commentProbability: Float,
     private val linkIssueProbability: Float,

--- a/custom-vu/src/main/kotlin/jces1209/vu/action/WorkOnIssue.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/action/WorkOnIssue.kt
@@ -28,7 +28,6 @@ class WorkOnIssue(
     private val jira: WebJira,
     private val measure: Measure,
     private var issueKeyMemory: IssueKeyMemory,
-    private val seededRandom: SeededRandom,
     private val editProbability: Float,
     private val commentProbability: Float,
     private val linkIssueProbability: Float,
@@ -41,12 +40,6 @@ class WorkOnIssue(
     private val logger: Logger = LogManager.getLogger(this::class.java)
 
     override fun run() {
-
-        val issueKeyMemoryIdsList: List<String> = getIssueKeyMemoryIds()
-        if(issueKeyMemoryIdsList.isNotEmpty()){
-            issueKeyMemory = AdaptiveIssueKeyMemory(seededRandom)
-            issueKeyMemory.remember(issueKeyMemoryIdsList)
-        }
 
         val issueKey = issueKeyMemory.recall()
         if (issueKey == null) {
@@ -180,19 +173,5 @@ class WorkOnIssue(
                 }
             }
         }
-    }
-
-    private fun getIssueKeyMemoryIds() : List<String> {
-        var issueKeyMemoryIdsList: List<String> = listOf()
-        val readTrafficShapeConfig = System.getenv("readTrafficShapeConfig")
-
-        if (!readTrafficShapeConfig.isNullOrEmpty()) {
-            val resourceName = TrafficDataParser.parseData(jira.base.host, readTrafficShapeConfig)
-            val properties = ConfigProperties.load(resourceName)
-
-            val issueKeyMemoryIds: String = properties.getProperty("action.issueKeyMemoryIds")
-            issueKeyMemoryIdsList = issueKeyMemoryIds.split(",").map { it.trim() }
-        }
-        return issueKeyMemoryIdsList
     }
 }

--- a/custom-vu/src/main/kotlin/jces1209/vu/action/WorkOnSearch.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/action/WorkOnSearch.kt
@@ -91,9 +91,10 @@ class WorkOnSearch(
     private fun customizeColumns() {
         measure.roll(customizeColumnsProbability) {
             jira.goToIssueNavigator("resolution = Unresolved ORDER BY priority DESC")
+            columnsEditor.selectView(1)
+            columnsEditor.openEditor()
+            columnsEditor.selectItems(2)
             measure.measure(MeasureType.CUSTOMIZE_COLUMNS) {
-                columnsEditor.openEditor()
-                columnsEditor.selectItems(2)
                 columnsEditor.submitSelection()
             }
         }

--- a/custom-vu/src/main/kotlin/jces1209/vu/action/WorkOnSprint.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/action/WorkOnSprint.kt
@@ -30,7 +30,7 @@ class WorkOnSprint(
     private fun workOnSprintPage() {
         val sprint = sprintsMemory.recall()
         if (sprint == null) {
-            logger.debug("I cannot recall active sprint board, skipping...")
+            println("I cannot recall active sprint board, skipping...")
             return
         }
 
@@ -41,20 +41,20 @@ class WorkOnSprint(
         if (sprint.maxColumnIssuesNumber() > 1) {
             reorderIssue(sprint)
         } else {
-            logger.debug("Scrum backlog doesn't contain enough issues to make reorder")
+            println("Scrum backlog doesn't contain enough issues to make reorder")
         }
 
-        if (sprint.isCompleteButtonPresent()) {
+        if (sprint.isCompleteButtonEnabled()) {
             completeSprint(sprint)
         } else {
-            logger.debug("Scrum backlog doesn't contain sprint which is ready to be completed")
+            println("Scrum backlog doesn't contain sprint which is ready to be completed")
         }
     }
 
     private fun workOnBacklog() {
         val backlog = backlogsMemory.recall()
         if (backlog == null) {
-            logger.debug("I cannot recall backlog, skipping...")
+            println("I cannot recall backlog, skipping...")
             return
         }
 
@@ -72,10 +72,10 @@ class WorkOnSprint(
                 if (backlog.isStartSprintEnabled()) {
                     startSprint(backlog)
                 } else {
-                    logger.debug("Can't start sprint - the option is disabled")
+                    println("Can't start sprint - the option is disabled")
                 }
             } else {
-                logger.debug("Scrum backlog doesn't contain issues in backlog")
+                println("Scrum backlog doesn't contain issues in backlog")
             }
         } finally {
             if (sprintApi.isReady()) {

--- a/custom-vu/src/main/kotlin/jces1209/vu/action/WorkOnTopBar.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/action/WorkOnTopBar.kt
@@ -1,9 +1,12 @@
 package jces1209.vu.action
 
-import com.atlassian.performance.tools.jiraactions.api.*
+import com.atlassian.performance.tools.jiraactions.api.WebJira
 import com.atlassian.performance.tools.jiraactions.api.action.Action
 import com.atlassian.performance.tools.jiraactions.api.measure.ActionMeter
+import com.atlassian.performance.tools.jiraactions.api.memories.IssueKeyMemory
 import jces1209.vu.MeasureType.Companion.TOP_BAR_QUICK_SEARCH
+import jces1209.vu.MeasureType.Companion.TOP_BAR_QUICK_SEARCH_SELECT_ITEM
+import jces1209.vu.page.JiraCloudProjectList
 import jces1209.vu.page.bars.topBar.TopBar
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
@@ -14,19 +17,27 @@ import org.apache.logging.log4j.Logger
 class WorkOnTopBar(
     private val topBar: TopBar,
     private val jira: WebJira,
-    private val meter: ActionMeter
+    private val meter: ActionMeter,
+    private val issueKeyMemory: IssueKeyMemory
 ) : Action {
     private val logger: Logger = LogManager.getLogger(this::class.java)
 
     override fun run() {
-        jira.navigateTo("secure/BrowseProjects.jspa")
-        quickSearch(topBar)
-    }
+        val issueKey = issueKeyMemory.recall()
+        if (issueKey == null) {
+            logger.debug("I don't recall any issue keys. Maybe next time I will.")
+            return
+        }
 
-    private fun quickSearch(topBar: TopBar) {
+        jira.navigateTo("projects")
+        JiraCloudProjectList(jira.driver).lookForProjects()
         topBar.waitForTopBar()
+
         meter.measure(TOP_BAR_QUICK_SEARCH) {
-            topBar.quickSearch()
+            topBar.quickSearch(issueKey)
+            meter.measure(TOP_BAR_QUICK_SEARCH_SELECT_ITEM) {
+                topBar.selectItem(issueKey)
+            }
         }
     }
 }

--- a/custom-vu/src/main/kotlin/jces1209/vu/api/ApiClient.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/api/ApiClient.kt
@@ -1,0 +1,6 @@
+package jces1209.vu.api
+
+interface ApiClient {
+
+    fun isReady(): Boolean
+}

--- a/custom-vu/src/main/kotlin/jces1209/vu/api/BaseApiClient.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/api/BaseApiClient.kt
@@ -2,12 +2,17 @@ package jces1209.vu.api
 
 import okhttp3.OkHttpClient
 import java.net.URI
+import java.util.concurrent.TimeUnit
 
 
 abstract class BaseApiClient(
     protected val url: URI
 ): ApiClient {
-    protected val okHttpClient = OkHttpClient()
+    protected val okHttpClient = OkHttpClient.Builder()
+        .connectTimeout(60, TimeUnit.SECONDS)
+        .readTimeout(60, TimeUnit.SECONDS)
+        .writeTimeout(60, TimeUnit.SECONDS)
+        .build()
 
     // TODO Get credentials from properties
     abstract fun getUser(): String?

--- a/custom-vu/src/main/kotlin/jces1209/vu/api/BaseApiClient.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/api/BaseApiClient.kt
@@ -1,0 +1,19 @@
+package jces1209.vu.api
+
+import okhttp3.OkHttpClient
+import java.net.URI
+
+
+abstract class BaseApiClient(
+    protected val url: URI
+): ApiClient {
+    protected val okHttpClient = OkHttpClient()
+
+    // TODO Get credentials from properties
+    abstract fun getUser(): String?
+    abstract fun getPassword(): String?
+
+    override fun isReady(): Boolean {
+        return getUser()?.isNotEmpty() ?: false && getPassword()?.isNotEmpty() ?: false
+    }
+}

--- a/custom-vu/src/main/kotlin/jces1209/vu/api/CloudApiClient.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/api/CloudApiClient.kt
@@ -1,5 +1,8 @@
 package jces1209.vu.api
 
+import okhttp3.Credentials
+import okhttp3.Request
+import okhttp3.Response
 import java.net.URI
 
 abstract class CloudApiClient(url: URI) : BaseApiClient(url) {
@@ -10,5 +13,17 @@ abstract class CloudApiClient(url: URI) : BaseApiClient(url) {
 
     override fun getPassword(): String {
         return ""
+    }
+
+    protected fun delete(uriPath: String): Pair<Request, Response> {
+        val request = Request.Builder()
+            .url("$url$uriPath")
+            .delete()
+            .addHeader("Accept", "application/json")
+            .addHeader("Authorization", Credentials.basic(getUser(), getPassword()))
+            .build()
+        val response = okHttpClient.newCall(request).execute()
+        println("Delete [$uriPath]. Response code [${response.code()}]. Body [${response.body()?.string()}], Request [$request]")
+        return Pair(request, response)
     }
 }

--- a/custom-vu/src/main/kotlin/jces1209/vu/api/CloudApiClient.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/api/CloudApiClient.kt
@@ -1,5 +1,6 @@
 package jces1209.vu.api
 
+import com.google.gson.Gson
 import okhttp3.Credentials
 import okhttp3.Request
 import okhttp3.Response
@@ -7,23 +8,38 @@ import java.net.URI
 
 abstract class CloudApiClient(url: URI) : BaseApiClient(url) {
 
+    val batchSize = 50
+
     override fun getUser(): String {
-        return ""
+        return CloudSettings.USER
     }
 
     override fun getPassword(): String {
-        return ""
+        return CloudSettings.PASSWORD
     }
 
     protected fun delete(uriPath: String): Pair<Request, Response> {
-        val request = Request.Builder()
-            .url("$url$uriPath")
+        val request = getRequestBuilder(uriPath)
             .delete()
-            .addHeader("Accept", "application/json")
-            .addHeader("Authorization", Credentials.basic(getUser(), getPassword()))
             .build()
         val response = okHttpClient.newCall(request).execute()
         println("Delete [$uriPath]. Response code [${response.code()}]. Body [${response.body()?.string()}], Request [$request]")
         return Pair(request, response)
+    }
+
+    private fun getRequestBuilder(uriPath: String): Request.Builder {
+        return Request.Builder()
+            .url("$url$uriPath")
+            .addHeader("Accept", "application/json")
+            .addHeader("Authorization", Credentials.basic(getUser(), getPassword()))
+    }
+
+    protected fun <T> get(uri: String, clazz: Class<T>): T {
+        val request = getRequestBuilder(uri)
+            .get()
+            .build()
+        val response = okHttpClient.newCall(request).execute().body()?.string()
+        println("Get request [$request] - Response [$response]")
+        return Gson().fromJson<T>(response, clazz)
     }
 }

--- a/custom-vu/src/main/kotlin/jces1209/vu/api/CloudApiClient.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/api/CloudApiClient.kt
@@ -1,0 +1,14 @@
+package jces1209.vu.api
+
+import java.net.URI
+
+abstract class CloudApiClient(url: URI) : BaseApiClient(url) {
+
+    override fun getUser(): String {
+        return ""
+    }
+
+    override fun getPassword(): String {
+        return ""
+    }
+}

--- a/custom-vu/src/main/kotlin/jces1209/vu/api/CloudSettings.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/api/CloudSettings.kt
@@ -1,0 +1,11 @@
+package jces1209.vu.api
+
+class CloudSettings {
+    companion object {
+        const val URL = ""
+        const val USER = ""
+        const val PASSWORD = ""
+        const val ACCOUNT_ID = ""
+        const val LAST_MIGRATED_SPRINT_ID = 9999999
+    }
+}

--- a/custom-vu/src/main/kotlin/jces1209/vu/api/DcApiClient.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/api/DcApiClient.kt
@@ -1,0 +1,13 @@
+package jces1209.vu.api
+
+import java.net.URI
+
+abstract class DcApiClient(url: URI) : BaseApiClient(url) {
+    override fun getUser(): String? {
+        return ""
+    }
+
+    override fun getPassword(): String? {
+        return ""
+    }
+}

--- a/custom-vu/src/main/kotlin/jces1209/vu/api/boards/BoardApi.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/api/boards/BoardApi.kt
@@ -1,0 +1,12 @@
+package jces1209.vu.api.boards
+
+import jces1209.vu.api.ApiClient
+import jces1209.vu.api.boards.model.Board
+import jces1209.vu.api.boards.model.Boards
+import jces1209.vu.api.sprint.model.Sprints
+
+interface BoardApi : ApiClient {
+
+    fun getScrumBoards(startAt: Int): Boards
+    fun getSprints(boardId: Int, startAt: Int): Sprints
+}

--- a/custom-vu/src/main/kotlin/jces1209/vu/api/boards/CloudBoardApi.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/api/boards/CloudBoardApi.kt
@@ -1,0 +1,19 @@
+package jces1209.vu.api.boards
+
+import jces1209.vu.api.CloudApiClient
+import jces1209.vu.api.boards.model.Boards
+import jces1209.vu.api.sprint.model.Sprints
+import java.net.URI
+
+class CloudBoardApi(url: URI) : CloudApiClient(url), BoardApi {
+
+    private val uri = "rest/agile/1.0/board/"
+
+    override fun getScrumBoards(startAt: Int): Boards {
+        return get("$uri?type=scrum&maxResults=$batchSize&startAt=$startAt", Boards::class.java)
+    }
+
+    override fun getSprints(boardId: Int, startAt: Int): Sprints {
+        return get("$uri$boardId/sprint?maxResults=$batchSize&startAt=$startAt", Sprints::class.java)
+    }
+}

--- a/custom-vu/src/main/kotlin/jces1209/vu/api/boards/DcBoardApi.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/api/boards/DcBoardApi.kt
@@ -1,0 +1,18 @@
+package jces1209.vu.api.boards
+
+import jces1209.vu.api.DcApiClient
+import jces1209.vu.api.boards.model.Board
+import jces1209.vu.api.boards.model.Boards
+import jces1209.vu.api.sprint.model.Sprints
+import java.net.URI
+
+class DcBoardApi(url: URI) : DcApiClient(url), BoardApi {
+
+    override fun getScrumBoards(startAt: Int): Boards {
+        TODO("Not yet implemented")
+    }
+
+    override fun getSprints(boardId: Int, startAt: Int): Sprints {
+        TODO("Not yet implemented")
+    }
+}

--- a/custom-vu/src/main/kotlin/jces1209/vu/api/boards/model/Board.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/api/boards/model/Board.kt
@@ -1,0 +1,5 @@
+package jces1209.vu.api.boards.model
+
+data class Board(
+    val id: Int
+)

--- a/custom-vu/src/main/kotlin/jces1209/vu/api/boards/model/Boards.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/api/boards/model/Boards.kt
@@ -1,0 +1,8 @@
+package jces1209.vu.api.boards.model
+
+import jces1209.vu.api.dashboard.model.Dashboard
+
+data class Boards(
+    val isLast: Boolean,
+    val values: List<Board>
+)

--- a/custom-vu/src/main/kotlin/jces1209/vu/api/dashboard/CloudDashboardApi.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/api/dashboard/CloudDashboardApi.kt
@@ -1,0 +1,12 @@
+package jces1209.vu.api.dashboard
+
+import jces1209.vu.api.CloudApiClient
+import java.net.URI
+
+class CloudDashboardApi(url: URI) : CloudApiClient(url), DashboardApi {
+    private val uri = "/rest/api/3/dashboard/"
+
+    override fun deleteDashboard(dashboardId: String) {
+        delete(uri + dashboardId)
+    }
+}

--- a/custom-vu/src/main/kotlin/jces1209/vu/api/dashboard/CloudDashboardApi.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/api/dashboard/CloudDashboardApi.kt
@@ -1,12 +1,19 @@
 package jces1209.vu.api.dashboard
 
 import jces1209.vu.api.CloudApiClient
+import jces1209.vu.api.dashboard.model.Dashboards
+import okhttp3.Response
 import java.net.URI
 
 class CloudDashboardApi(url: URI) : CloudApiClient(url), DashboardApi {
-    private val uri = "/rest/api/3/dashboard/"
+    private val uri = "rest/api/3/dashboard/"
+    private val uriSearch = "rest/api/3/dashboard/search"
 
-    override fun deleteDashboard(dashboardId: String) {
-        delete(uri + dashboardId)
+    override fun deleteDashboard(dashboardId: String): Response {
+        return delete(uri + dashboardId).second
+    }
+
+    override fun getDashboards(accountId: String): Dashboards {
+        return get("$uriSearch?accountId=$accountId", Dashboards::class.java)
     }
 }

--- a/custom-vu/src/main/kotlin/jces1209/vu/api/dashboard/DashboardApi.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/api/dashboard/DashboardApi.kt
@@ -1,0 +1,8 @@
+package jces1209.vu.api.dashboard
+
+import jces1209.vu.api.ApiClient
+
+interface DashboardApi : ApiClient {
+
+    fun deleteDashboard(dashboardId: String)
+}

--- a/custom-vu/src/main/kotlin/jces1209/vu/api/dashboard/DashboardApi.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/api/dashboard/DashboardApi.kt
@@ -1,8 +1,11 @@
 package jces1209.vu.api.dashboard
 
 import jces1209.vu.api.ApiClient
+import jces1209.vu.api.dashboard.model.Dashboards
+import okhttp3.Response
 
 interface DashboardApi : ApiClient {
 
-    fun deleteDashboard(dashboardId: String)
+    fun deleteDashboard(dashboardId: String): Response
+    fun getDashboards(accountId: String): Dashboards
 }

--- a/custom-vu/src/main/kotlin/jces1209/vu/api/dashboard/DcDashboardApi.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/api/dashboard/DcDashboardApi.kt
@@ -1,11 +1,17 @@
 package jces1209.vu.api.dashboard
 
 import jces1209.vu.api.DcApiClient
+import jces1209.vu.api.dashboard.model.Dashboards
+import okhttp3.Response
 import java.net.URI
 
-class DcDashboardApi(url: URI) : DcApiClient(url), DashboardApi  {
+class DcDashboardApi(url: URI) : DcApiClient(url), DashboardApi {
 
-    override fun deleteDashboard(dashboardId: String) {
+    override fun deleteDashboard(dashboardId: String): Response {
+        TODO("Not yet implemented")
+    }
+
+    override fun getDashboards(accountId: String): Dashboards {
         TODO("Not yet implemented")
     }
 }

--- a/custom-vu/src/main/kotlin/jces1209/vu/api/dashboard/DcDashboardApi.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/api/dashboard/DcDashboardApi.kt
@@ -1,0 +1,11 @@
+package jces1209.vu.api.dashboard
+
+import jces1209.vu.api.DcApiClient
+import java.net.URI
+
+class DcDashboardApi(url: URI) : DcApiClient(url), DashboardApi  {
+
+    override fun deleteDashboard(dashboardId: String) {
+        TODO("Not yet implemented")
+    }
+}

--- a/custom-vu/src/main/kotlin/jces1209/vu/api/dashboard/model/Dashboard.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/api/dashboard/model/Dashboard.kt
@@ -1,0 +1,5 @@
+package jces1209.vu.api.dashboard.model
+
+data class Dashboard(
+    val id: String
+)

--- a/custom-vu/src/main/kotlin/jces1209/vu/api/dashboard/model/Dashboards.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/api/dashboard/model/Dashboards.kt
@@ -1,0 +1,6 @@
+package jces1209.vu.api.dashboard.model
+
+data class Dashboards(
+    val isLast: Boolean,
+    val values: List<Dashboard>
+)

--- a/custom-vu/src/main/kotlin/jces1209/vu/api/issue/CloudIssueApi.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/api/issue/CloudIssueApi.kt
@@ -1,26 +1,13 @@
 package jces1209.vu.api.issue
 
 import jces1209.vu.api.CloudApiClient
-import okhttp3.Credentials
-import okhttp3.OkHttpClient
-import okhttp3.Request
-import org.apache.logging.log4j.LogManager
-import org.apache.logging.log4j.Logger
 import java.net.URI
 
 class CloudIssueApi(url: URI) : CloudApiClient(url), IssueApi {
 
-    private val logger: Logger = LogManager.getLogger(this::class.java)
-    private val issuesUri = "/rest/api/3/issue/"
+    private val uri = "/rest/api/3/issue/"
 
     override fun deleteIssue(issueKey: String) {
-        val request = Request.Builder()
-            .url("$url$issuesUri$issueKey")
-            .delete()
-            .addHeader("Accept", "application/json")
-            .addHeader("Authorization", Credentials.basic(getUser(), getPassword()))
-            .build()
-        val response = okHttpClient.newCall(request).execute()
-        println("Delete issue. Response code [${response.code()}]. Body [${response.body()?.string()}], Request [$request]")
+        delete(uri + issueKey)
     }
 }

--- a/custom-vu/src/main/kotlin/jces1209/vu/api/issue/CloudIssueApi.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/api/issue/CloudIssueApi.kt
@@ -1,13 +1,20 @@
 package jces1209.vu.api.issue
 
 import jces1209.vu.api.CloudApiClient
+import jces1209.vu.api.issue.model.Issues
+import okhttp3.Response
 import java.net.URI
 
 class CloudIssueApi(url: URI) : CloudApiClient(url), IssueApi {
 
-    private val uri = "/rest/api/3/issue/"
+    private val uri = "rest/api/3/issue/"
+    private val uriSearch = "rest/api/3/search"
 
-    override fun deleteIssue(issueKey: String) {
-        delete(uri + issueKey)
+    override fun deleteIssue(issueKey: String): Response {
+        return delete(uri + issueKey).second
+    }
+
+    override fun getIssues(accountId: String, startAt: Int): Issues {
+        return get("$uriSearch?jql=creator in ($accountId)&fields=key&startAt=$startAt", Issues::class.java)
     }
 }

--- a/custom-vu/src/main/kotlin/jces1209/vu/api/issue/CloudIssueApi.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/api/issue/CloudIssueApi.kt
@@ -1,0 +1,26 @@
+package jces1209.vu.api.issue
+
+import jces1209.vu.api.CloudApiClient
+import okhttp3.Credentials
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
+import java.net.URI
+
+class CloudIssueApi(url: URI) : CloudApiClient(url), IssueApi {
+
+    private val logger: Logger = LogManager.getLogger(this::class.java)
+    private val issuesUri = "/rest/api/3/issue/"
+
+    override fun deleteIssue(issueKey: String) {
+        val request = Request.Builder()
+            .url("$url$issuesUri$issueKey")
+            .delete()
+            .addHeader("Accept", "application/json")
+            .addHeader("Authorization", Credentials.basic(getUser(), getPassword()))
+            .build()
+        val response = okHttpClient.newCall(request).execute()
+        println("Delete issue. Response code [${response.code()}]. Body [${response.body()?.string()}], Request [$request]")
+    }
+}

--- a/custom-vu/src/main/kotlin/jces1209/vu/api/issue/DcIssueApi.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/api/issue/DcIssueApi.kt
@@ -1,0 +1,16 @@
+package jces1209.vu.api.issue
+
+import jces1209.vu.api.DcApiClient
+import okhttp3.Credentials
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
+import java.net.URI
+
+class DcIssueApi(url: URI) : DcApiClient(url), IssueApi {
+
+    override fun deleteIssue(issueKey: String) {
+        TODO("Not yet implemented")
+    }
+}

--- a/custom-vu/src/main/kotlin/jces1209/vu/api/issue/DcIssueApi.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/api/issue/DcIssueApi.kt
@@ -1,16 +1,22 @@
 package jces1209.vu.api.issue
 
 import jces1209.vu.api.DcApiClient
+import jces1209.vu.api.issue.model.Issues
 import okhttp3.Credentials
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import okhttp3.Response
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 import java.net.URI
 
 class DcIssueApi(url: URI) : DcApiClient(url), IssueApi {
 
-    override fun deleteIssue(issueKey: String) {
+    override fun deleteIssue(issueKey: String): Response {
+        TODO("Not yet implemented")
+    }
+
+    override fun getIssues(accountId: String, startAt: Int): Issues {
         TODO("Not yet implemented")
     }
 }

--- a/custom-vu/src/main/kotlin/jces1209/vu/api/issue/IssueApi.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/api/issue/IssueApi.kt
@@ -3,5 +3,6 @@ package jces1209.vu.api.issue
 import jces1209.vu.api.ApiClient
 
 interface IssueApi : ApiClient {
+
     fun deleteIssue(issueKey: String)
 }

--- a/custom-vu/src/main/kotlin/jces1209/vu/api/issue/IssueApi.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/api/issue/IssueApi.kt
@@ -1,0 +1,7 @@
+package jces1209.vu.api.issue
+
+import jces1209.vu.api.ApiClient
+
+interface IssueApi : ApiClient {
+    fun deleteIssue(issueKey: String)
+}

--- a/custom-vu/src/main/kotlin/jces1209/vu/api/issue/IssueApi.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/api/issue/IssueApi.kt
@@ -1,8 +1,12 @@
 package jces1209.vu.api.issue
 
 import jces1209.vu.api.ApiClient
+import jces1209.vu.api.dashboard.model.Dashboards
+import jces1209.vu.api.issue.model.Issues
+import okhttp3.Response
 
 interface IssueApi : ApiClient {
 
-    fun deleteIssue(issueKey: String)
+    fun deleteIssue(issueKey: String): Response
+    fun getIssues(accountId: String, startAt: Int): Issues
 }

--- a/custom-vu/src/main/kotlin/jces1209/vu/api/issue/model/Issue.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/api/issue/model/Issue.kt
@@ -1,0 +1,6 @@
+package jces1209.vu.api.issue.model
+
+data class Issue(
+    val id: String,
+    val key: String
+)

--- a/custom-vu/src/main/kotlin/jces1209/vu/api/issue/model/Issues.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/api/issue/model/Issues.kt
@@ -1,0 +1,6 @@
+package jces1209.vu.api.issue.model
+
+data class Issues(
+    val total: Int,
+    val issues: List<Issue>
+)

--- a/custom-vu/src/main/kotlin/jces1209/vu/api/sprint/CloudSprintApi.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/api/sprint/CloudSprintApi.kt
@@ -1,13 +1,14 @@
 package jces1209.vu.api.sprint
 
 import jces1209.vu.api.CloudApiClient
+import okhttp3.Response
 import java.net.URI
 
 class CloudSprintApi(url: URI) : CloudApiClient(url), SprintApi {
 
-    private val uri = "/rest/agile/1.0/sprint/"
+    private val uri = "rest/agile/1.0/sprint/"
 
-    override fun deleteSprint(sprintId: String) {
-        delete(uri + sprintId)
+    override fun deleteSprint(sprintId: String): Response {
+        return delete(uri + sprintId).second
     }
 }

--- a/custom-vu/src/main/kotlin/jces1209/vu/api/sprint/CloudSprintApi.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/api/sprint/CloudSprintApi.kt
@@ -1,0 +1,13 @@
+package jces1209.vu.api.sprint
+
+import jces1209.vu.api.CloudApiClient
+import java.net.URI
+
+class CloudSprintApi(url: URI) : CloudApiClient(url), SprintApi {
+
+    private val uri = "/rest/agile/1.0/sprint/"
+
+    override fun deleteSprint(sprintId: String) {
+        delete(uri + sprintId)
+    }
+}

--- a/custom-vu/src/main/kotlin/jces1209/vu/api/sprint/DcSprintApi.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/api/sprint/DcSprintApi.kt
@@ -4,13 +4,14 @@ import jces1209.vu.api.DcApiClient
 import okhttp3.Credentials
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import okhttp3.Response
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 import java.net.URI
 
 class DcSprintApi(url: URI) : DcApiClient(url), SprintApi {
 
-    override fun deleteSprint(sprintId: String) {
+    override fun deleteSprint(sprintId: String): Response {
         TODO("Not yet implemented")
     }
 }

--- a/custom-vu/src/main/kotlin/jces1209/vu/api/sprint/DcSprintApi.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/api/sprint/DcSprintApi.kt
@@ -1,0 +1,16 @@
+package jces1209.vu.api.sprint
+
+import jces1209.vu.api.DcApiClient
+import okhttp3.Credentials
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
+import java.net.URI
+
+class DcSprintApi(url: URI) : DcApiClient(url), SprintApi {
+
+    override fun deleteSprint(sprintId: String) {
+        TODO("Not yet implemented")
+    }
+}

--- a/custom-vu/src/main/kotlin/jces1209/vu/api/sprint/SprintApi.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/api/sprint/SprintApi.kt
@@ -1,8 +1,9 @@
 package jces1209.vu.api.sprint
 
 import jces1209.vu.api.ApiClient
+import okhttp3.Response
 
 interface SprintApi : ApiClient {
 
-    fun deleteSprint(sprintId: String)
+    fun deleteSprint(sprintId: String): Response
 }

--- a/custom-vu/src/main/kotlin/jces1209/vu/api/sprint/SprintApi.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/api/sprint/SprintApi.kt
@@ -1,0 +1,8 @@
+package jces1209.vu.api.sprint
+
+import jces1209.vu.api.ApiClient
+
+interface SprintApi : ApiClient {
+
+    fun deleteSprint(sprintId: String)
+}

--- a/custom-vu/src/main/kotlin/jces1209/vu/api/sprint/model/Sprint.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/api/sprint/model/Sprint.kt
@@ -1,0 +1,5 @@
+package jces1209.vu.api.sprint.model
+
+data class Sprint(
+    val id: Int
+)

--- a/custom-vu/src/main/kotlin/jces1209/vu/api/sprint/model/Sprints.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/api/sprint/model/Sprints.kt
@@ -1,0 +1,6 @@
+package jces1209.vu.api.sprint.model
+
+data class Sprints(
+    val isLast: Boolean,
+    val values: List<Sprint>?
+)

--- a/custom-vu/src/main/kotlin/jces1209/vu/page/ClassicCloudCommenting.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/page/ClassicCloudCommenting.kt
@@ -2,17 +2,18 @@ package jces1209.vu.page
 
 import jces1209.vu.wait
 import org.openqa.selenium.By
+import org.openqa.selenium.JavascriptExecutor
 import org.openqa.selenium.WebDriver
 import org.openqa.selenium.interactions.Actions
+import org.openqa.selenium.support.ui.ExpectedConditions
 import org.openqa.selenium.support.ui.ExpectedConditions.elementToBeClickable
 import org.openqa.selenium.support.ui.ExpectedConditions.visibilityOfElementLocated
-import org.openqa.selenium.support.ui.ExpectedConditions
 
 class ClassicCloudCommenting(
     private val driver: WebDriver
 ) : Commenting {
 
-    private val commentButton = By.id("footer-comment-button")
+    private val commentButton = By.xpath("//a[@id='footer-comment-button' and not (@disabled)]")
     private val falliblePage = FalliblePage.Builder(
         expectedContent = listOf(commentButton),
         webDriver = driver
@@ -22,9 +23,7 @@ class ClassicCloudCommenting(
 
     override fun openEditor() {
         falliblePage.waitForPageToLoad()
-        driver
-            .wait(elementToBeClickable(commentButton))
-            .click()
+        (driver as JavascriptExecutor).executeScript("arguments[0].click();", driver.findElement(commentButton))
         waitForEditor()
     }
 
@@ -41,7 +40,7 @@ class ClassicCloudCommenting(
     }
 
     override fun saveComment() {
-        driver.findElement(By.id("issue-comment-add-submit")).click()
+        driver.findElement(By.xpath("//input[@id='issue-comment-add-submit' and not(@disabled)]")).click()
     }
 
     override fun waitForTheNewComment() {

--- a/custom-vu/src/main/kotlin/jces1209/vu/page/CloudIssuePage.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/page/CloudIssuePage.kt
@@ -1,13 +1,10 @@
 package jces1209.vu.page
-
 import com.atlassian.performance.tools.jiraactions.api.page.wait
 import jces1209.vu.page.contextoperation.ContextOperationIssue
 import jces1209.vu.wait
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
-import org.openqa.selenium.By
-import org.openqa.selenium.WebDriver
-import org.openqa.selenium.WebElement
+import org.openqa.selenium.*
 import org.openqa.selenium.interactions.Actions
 import org.openqa.selenium.support.ui.ExpectedConditions.invisibilityOfAllElements
 import org.openqa.selenium.support.ui.ExpectedConditions.presenceOfElementLocated
@@ -75,33 +72,7 @@ class CloudIssuePage(
     }
 
     override fun changeAssignee(): CloudIssuePage {
-        driver
-            .findElement(By.cssSelector("[data-test-id = 'issue.views.field.user.assignee']"))
-            .click();
-
-        var userList = driver
-            .wait(
-                ExpectedConditions.presenceOfAllElementsLocatedBy(By.xpath("//*[contains(@class,'fabric-user-picker__menu-list')]/*"))
-            )
-
-        if (userList.size == 1 && userList[0].text == "No options") {
-            logger.debug("No user options for Assignee")
-            throw InterruptedException("No options for Assignee")
-        }
-
-        val firstUser = driver
-            .wait(
-                ExpectedConditions.presenceOfElementLocated(By.id("react-select-assignee-option-0"))
-            )
-
-        var userName = firstUser.text.removeSuffix(" (Assign to me)")
-        firstUser.click()
-
-        driver.wait(
-            ExpectedConditions.presenceOfElementLocated(By.xpath("//*[@data-test-id='issue.views.field.user.assignee']//*[.='$userName']"))
-        )
-
-        return this;
+        return if (isBentoViewEnabled()) changeAssigneeBentoView() else changeAssigneeClassicView()
     }
 
     override fun contextOperation(): ContextOperationIssue {
@@ -135,7 +106,6 @@ class CloudIssuePage(
                 timeout = Duration.ofSeconds(7),
                 condition = ExpectedConditions.invisibilityOfElementLocated(transitionCancelLocator)
             )
-
         return this
     }
 
@@ -212,6 +182,72 @@ class CloudIssuePage(
             )
             .click()
         return this
+    }
+
+    fun changeAssigneeBentoView(): CloudIssuePage {
+        driver
+            .findElement(By.cssSelector("[data-test-id = 'issue.views.field.user.assignee']"))
+            .click();
+
+        var userList = driver
+            .wait(
+                ExpectedConditions.presenceOfAllElementsLocatedBy(By.xpath("//*[contains(@class,'fabric-user-picker__menu-list')]/*"))
+            )
+
+        if (userList.size == 1 && userList[0].text == "No options") {
+            logger.debug("No user options for Assignee")
+            throw InterruptedException("No options for Assignee")
+        }
+
+        val firstUser = driver
+            .wait(presenceOfElementLocated(By.id("react-select-assignee-option-0")))
+
+        var userName = firstUser.text.removeSuffix(" (Assign to me)")
+        firstUser.click()
+        driver.wait(presenceOfElementLocated(By.xpath("//*[@data-test-id='issue.views.field.user.assignee']//*[.='$userName']")))
+        return this;
+    }
+
+    private fun changeAssigneeClassicView(): CloudIssuePage {
+        driver
+            .wait(elementToBeClickable(By.xpath("//span[@id='assignee-val' and not (@inactive)]")))
+            .click()
+        driver
+            .wait(visibilityOfElementLocated(By.xpath("//span[@id='assignee-val'][contains(@class,'active')]")))
+        driver
+            .wait(visibilityOfElementLocated(By.xpath("//form[@id='assignee-form']//span[contains(@class, 'drop-menu')]")))
+            .click()
+
+        val userList = try {
+            driver.wait(presenceOfAllElementsLocatedBy(By.xpath("//ul[@id='suggestions']//a")))
+        } catch (exc: Exception) {
+            logger.debug("No user options for Assignee")
+            throw InterruptedException("No options for Assignee")
+        }
+
+        val firstUser = driver.findElement(By.xpath("//ul[@id='suggestions']/li[1]/a"))
+        var firstUserName = firstUser.getAttribute("text")
+        if (userList.size == 1 && firstUserName == "Automatic") {
+            firstUserName = "Unassigned"
+        }
+
+        firstUser.click()
+        driver
+            .wait(elementToBeClickable(By.xpath("//button[@type='submit']")))
+            .click()
+        driver
+            .wait(presenceOfElementLocated(By.xpath("//*[text()[contains(.,'$firstUserName')]]")))
+        return this;
+    }
+
+    private fun isBentoViewEnabled(): Boolean {
+        try {
+            driver
+                .wait(presenceOfElementLocated(bentoSummary))
+        } catch (exc: Exception) {
+            return false
+        }
+        return true
     }
 
     private fun isCommentingClassic(): Boolean = driver

--- a/custom-vu/src/main/kotlin/jces1209/vu/page/JiraCloudWelcome.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/page/JiraCloudWelcome.kt
@@ -2,6 +2,7 @@ package jces1209.vu.page
 
 import jces1209.vu.wait
 import org.openqa.selenium.By
+import org.openqa.selenium.TimeoutException
 import org.openqa.selenium.WebDriver
 import org.openqa.selenium.support.ui.ExpectedConditions.*
 
@@ -11,12 +12,16 @@ class JiraCloudWelcome(
 
     fun skipToJira() = apply {
         val questionSkip = By.xpath("//*[contains(text(), 'Skip question')]")
-        driver.wait(
-            or(
-                presenceOfElementLocated(By.id("jira")),
-                elementToBeClickable(questionSkip)
+        try {
+            driver.wait(
+                or(
+                    presenceOfElementLocated(By.id("jira")),
+                    elementToBeClickable(questionSkip)
+                )
             )
-        )
+        } catch (exc: TimeoutException) {
+            driver.navigate().refresh()
+        }
         repeat(2) {
             driver
                 .findElements(questionSkip)

--- a/custom-vu/src/main/kotlin/jces1209/vu/page/JiraTips.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/page/JiraTips.kt
@@ -48,5 +48,14 @@ class JiraTips(
                     .click()
                 driver.wait(ExpectedConditions.invisibilityOf(it))
             }
+        driver
+            .findElements(By.xpath("//img[contains(@alt, 'Jira Service Desk')]"))
+            .filter {it.isDisplayed}
+            .forEach{
+                it
+                    .findElement(By.xpath("//span[.='Ok, thanks']"))
+                    .click()
+                driver.wait(ExpectedConditions.invisibilityOf(it))
+            }
     }
 }

--- a/custom-vu/src/main/kotlin/jces1209/vu/page/admin/issuetypes/CloudBrowseIssueTypesPage.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/page/admin/issuetypes/CloudBrowseIssueTypesPage.kt
@@ -3,6 +3,8 @@ package jces1209.vu.page.admin.issuetypes
 import com.atlassian.performance.tools.jiraactions.api.WebJira
 import jces1209.vu.page.FalliblePage
 import org.openqa.selenium.By
+import org.openqa.selenium.support.ui.ExpectedCondition
+import org.openqa.selenium.support.ui.ExpectedConditions
 import org.openqa.selenium.support.ui.ExpectedConditions.*
 import java.lang.Exception
 import java.time.Duration
@@ -15,7 +17,10 @@ class CloudBrowseIssueTypesPage(
         jira.driver,
         and(
             loadingPageExpectedCondition,
-            presenceOfAllElementsLocatedBy(By.xpath("//*[@data-testid = 'NavigationItem']")),
+            or(
+                presenceOfAllElementsLocatedBy(By.xpath("//div[@role='group']/a")),
+                presenceOfAllElementsLocatedBy(By.xpath("//*[@data-testid = 'NavigationItem']"))
+            ),
             presenceOfElementLocated(By.xpath("//*[. = 'Issue types']")),
             presenceOfElementLocated(By.className("search-entry"))
         )

--- a/custom-vu/src/main/kotlin/jces1209/vu/page/bars/side/CloudSideBar.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/page/bars/side/CloudSideBar.kt
@@ -75,7 +75,7 @@ class CloudSideBar(
     }
 
     private fun getNavigatorItemLocator(itemName: String): By {
-        return By.xpath("//a[@data-testid='NavigationItem' and div/div[text()='$itemName']]")
+        return By.xpath("//div[@role='group']//span[contains(text(), '$itemName')]/ancestor::a")
     }
 
     private val loadingLocator = By.cssSelector(".details-layout > .loading")

--- a/custom-vu/src/main/kotlin/jces1209/vu/page/bars/topBar/TopBar.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/page/bars/topBar/TopBar.kt
@@ -1,6 +1,10 @@
 package jces1209.vu.page.bars.topBar
 
+import com.atlassian.performance.tools.jiraactions.api.page.IssuePage
+import jces1209.vu.page.AbstractIssuePage
+
 interface TopBar {
     fun waitForTopBar(): TopBar
-    fun quickSearch(): TopBar
+    fun quickSearch(issueKey: String): TopBar
+    fun selectItem(issueKey: String): AbstractIssuePage
 }

--- a/custom-vu/src/main/kotlin/jces1209/vu/page/bars/topBar/cloud/CloudTopBar.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/page/bars/topBar/cloud/CloudTopBar.kt
@@ -1,4 +1,3 @@
-package jces1209.vu.page.bars.topBar.cloud
 
 import com.atlassian.performance.tools.jiraactions.api.page.wait
 import jces1209.vu.page.AbstractIssuePage
@@ -27,7 +26,7 @@ class CloudTopBar(
 
         driver
             .wait(visibilityOfElementLocated(By.xpath("//span[text()='Advanced issue search']"))
-        )
+            )
 
         Actions(driver)
             .sendKeys(issueKey)

--- a/custom-vu/src/main/kotlin/jces1209/vu/page/bars/topBar/cloud/CloudTopBar.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/page/bars/topBar/cloud/CloudTopBar.kt
@@ -1,5 +1,6 @@
 package jces1209.vu.page.bars.topBar.cloud
 
+import com.atlassian.performance.tools.jiraactions.api.page.wait
 import jces1209.vu.page.AbstractIssuePage
 import jces1209.vu.page.CloudIssuePage
 import jces1209.vu.page.bars.topBar.TopBar
@@ -7,8 +8,8 @@ import jces1209.vu.wait
 import org.openqa.selenium.By
 import org.openqa.selenium.WebDriver
 import org.openqa.selenium.interactions.Actions
-import org.openqa.selenium.support.ui.ExpectedConditions
-import org.openqa.selenium.support.ui.ExpectedConditions.visibilityOfElementLocated
+import org.openqa.selenium.support.ui.ExpectedConditions.*
+import java.time.Duration
 
 class CloudTopBar(
     private val driver: WebDriver
@@ -20,9 +21,13 @@ class CloudTopBar(
     }
 
     override fun quickSearch(issueKey: String): CloudTopBar {
-        Actions(driver)
-            .sendKeys("/")
-            .perform()
+        driver
+            .wait(visibilityOfElementLocated(By.xpath("//input[@data-test-id='search-dialog-input']")))
+            .click()
+
+        driver
+            .wait(visibilityOfElementLocated(By.xpath("//span[text()='Advanced issue search']"))
+        )
 
         Actions(driver)
             .sendKeys(issueKey)
@@ -30,10 +35,11 @@ class CloudTopBar(
 
         driver
             .wait(
-                ExpectedConditions.and(
-                    ExpectedConditions.presenceOfAllElementsLocatedBy(generateIssueItemLocator(issueKey)),
-                    ExpectedConditions.presenceOfAllElementsLocatedBy(By.xpath("//*[@data-test-id='search-dialog-dialog-wrapper']//*[contains(text(), 'Boards, Projects, Filters and Plans')]"))
-                )
+                condition = and(
+                    presenceOfAllElementsLocatedBy(generateIssueItemLocator(issueKey)),
+                    presenceOfAllElementsLocatedBy(By.xpath("//*[@data-test-id='search-dialog-dialog-wrapper']//*[contains(text(), 'Boards, Projects, Filters and Plans')]"))
+                ),
+                timeout = Duration.ofSeconds(10)
             )
         return this
     }

--- a/custom-vu/src/main/kotlin/jces1209/vu/page/bars/topBar/dc/DcTopBar.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/page/bars/topBar/dc/DcTopBar.kt
@@ -1,5 +1,6 @@
 package jces1209.vu.page.bars.topBar.dc
 
+import jces1209.vu.page.AbstractIssuePage
 import jces1209.vu.page.FalliblePage
 import jces1209.vu.page.bars.topBar.TopBar
 import jces1209.vu.wait
@@ -30,7 +31,7 @@ class DcTopBar(
         return this
     }
 
-    override fun quickSearch(): DcTopBar {
+    override fun quickSearch(issueKey: String): DcTopBar {
         Actions(driver)
             .sendKeys("/")
             .perform()
@@ -44,5 +45,9 @@ class DcTopBar(
                 )
             )
         return this
+    }
+
+    override fun selectItem(issueKey: String): AbstractIssuePage {
+        TODO("Not yet implemented")
     }
 }

--- a/custom-vu/src/main/kotlin/jces1209/vu/page/boards/view/MovingIssue.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/page/boards/view/MovingIssue.kt
@@ -43,19 +43,35 @@ class MovingIssue(
             .moveToElement(driver
                 .findElements(moveZoneLocator)
                 .first { it.isDisplayed })
+            .perform()
+
+        //adding delay for jira to recognize dragAndDrop action and react to it
+        Thread.sleep(1000)
+        Actions(driver)
             .release()
             .perform()
 
-
         val issue = Issue(columnFromIndex, issueKey)
 
+        val conditionMessageVisibility = visibilityOfAllElementsLocatedBy(By.className("global-msg"))
         driver
             .wait(
                 or(
                     visibilityOfElementLocated(modalDialogLocator),
-                    movedIssueExpectedCondition(issue)
+                    movedIssueExpectedCondition(issue),
+                    conditionMessageVisibility
                 )
             )
+
+        if (!movedIssueExpectedCondition(issue).apply(driver)!!) {
+            val messages = conditionMessageVisibility.apply(driver)
+            if (messages == null || messages.isEmpty()) {
+                throw RuntimeException("Failed to move issue [${issue.key}]")
+            } else {
+                throw InterruptedException("The issue [${issue.key}] can't be moved. Error messages [$messages]")
+            }
+        }
+
         return issue
     }
 
@@ -64,7 +80,7 @@ class MovingIssue(
     }
 
     fun isContinueButtonEnabled(): Boolean {
-        return driver.findElements(transitionSubmitButtonLocator).filter { it.isEnabled }.isNotEmpty()
+        return driver.findElements(transitionSubmitButtonLocator).any { it.isEnabled }
     }
 
     private fun movedIssueExpectedCondition(issue: Issue): ExpectedCondition<Boolean> {

--- a/custom-vu/src/main/kotlin/jces1209/vu/page/boards/view/ScrumBacklogPage.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/page/boards/view/ScrumBacklogPage.kt
@@ -42,7 +42,7 @@ abstract class ScrumBacklogPage(
             .size
     }
 
-    fun createSprint(): ScrumBacklogPage {
+    fun createSprint(): String {
         val sprintContainerLocator = By.className("js-sprint-header")
 
         val createSprintButton = driver.wait(
@@ -60,7 +60,7 @@ abstract class ScrumBacklogPage(
                 driver.findElements(sprintContainerLocator).size > sprintsNumberBeforeCreate
             })
 
-        return this
+        return driver.findElements(sprintContainerLocator).last().getAttribute("data-sprint-id")
     }
 
     fun moveIssueToSprint(): ScrumBacklogPage {

--- a/custom-vu/src/main/kotlin/jces1209/vu/page/boards/view/ScrumSprintPage.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/page/boards/view/ScrumSprintPage.kt
@@ -40,25 +40,50 @@ abstract class ScrumSprintPage(
             .first()
             .text
 
-        val issues = columns[columnIndex]
+        val firstIssue = columns[columnIndex]
             .findElements(By.cssSelector(".ghx-card-footer, .ghx-grabber"))
+            .first()
+        val targetIssue = columns[columnIndex]
+            .findElements(By.className("ghx-issuekey-number"))
+            .elementAt(1)
+
         Actions(driver)
-            .dragAndDrop(issues.first(), issues.elementAt(1))
+            .moveToElement(firstIssue)
+            .perform()
+        //adding delay to start dragAndDrop action
+        Thread.sleep(200)
+
+        Actions(driver)
+            .clickAndHold()
+            .perform()
+        //adding delay to proceed with dragAndDrop
+        Thread.sleep(150)
+
+        Actions(driver)
+            .moveToElement(targetIssue)
+            .perform()
+        //adding delay to complete dragAndDrop
+        Thread.sleep(100)
+
+        Actions(driver)
+            .release()
             .perform()
 
         driver.wait(
             ExpectedCondition {
                 columns()[columnIndex]
                     .findElements(issueSummaryLocator)
-                    .elementAt(1)
-                    .text == issueFirstText
+                    .elementAt(0)
+                    .text != issueFirstText
             })
     }
 
-    fun isCompleteButtonPresent(): Boolean {
-        return driver
-            .findElements(completeButtonLocator)
-            .isNotEmpty()
+    fun isCompleteButtonEnabled(): Boolean {
+        val completeButton = driver.findElements(completeButtonLocator)
+        if (completeButton.isNotEmpty()) {
+            return completeButton[0].isEnabled
+        }
+        return false
     }
 
     fun completeSprint() {

--- a/custom-vu/src/main/kotlin/jces1209/vu/page/customizecolumns/ColumnsEditor.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/page/customizecolumns/ColumnsEditor.kt
@@ -1,40 +1,95 @@
 package jces1209.vu.page.customizecolumns
 
 import com.atlassian.performance.tools.jiraactions.api.page.wait
-import jces1209.vu.wait
 import org.openqa.selenium.By
+import org.openqa.selenium.JavascriptExecutor
 import org.openqa.selenium.WebDriver
-import org.openqa.selenium.WebElement
 import org.openqa.selenium.support.ui.ExpectedConditions
 import java.time.Duration
 
 abstract class ColumnsEditor(
     private val driver: WebDriver
 ) {
+    val columnCheckbox = By.xpath(".//*[@class='check-list-item']")
+
+    fun selectView(view: Int) {
+        driver.wait(
+            condition = ExpectedConditions.elementToBeClickable(By.xpath(
+                ".//button[@id='layout-switcher-button']")),
+            timeout = Duration.ofSeconds(15)
+        ).click()
+        if (view == 1) {
+            driver.wait(
+                condition = ExpectedConditions.elementToBeClickable(By.xpath(
+                    ".//div[@class='aui-list']" +
+                        "//*[@data-layout-key='list-view']")),
+                timeout = Duration.ofSeconds(5)
+            ).click()
+        } else if (view == 0) {
+            driver.wait(
+                condition = ExpectedConditions.elementToBeClickable(By.xpath(
+                    ".//div[@class='aui-list']" +
+                        "//*[@data-layout-key='split-view']")),
+                timeout = Duration.ofSeconds(5)
+            ).click()
+        }
+    }
 
     fun openEditor() {
-        driver.wait(
-            condition = ExpectedConditions.elementToBeClickable(By.className(
-                "aui-button aui-button-subtle column-picker-trigger")),
-            timeout = Duration.ofSeconds(5)
-        ).click()
-
+        openColumnsList()
+        restoreDefaults()
+        openColumnsList()
     }
 
     fun selectItems(itemsCount: Int) {
-        val items: List<WebElement>
-        items = driver.findElements(By.xpath("(//input[@type='checkbox'])"))
+        driver.wait(
+            condition = ExpectedConditions.numberOfElementsToBeMoreThan(columnCheckbox, 0),
+            timeout = Duration.ofSeconds(15)
+        )
+        val items = driver.findElements(columnCheckbox)
+
         for (i: Int in 0 until itemsCount) {
+            driver.wait(
+                condition = ExpectedConditions.elementToBeClickable(items[i]),
+                timeout = Duration.ofSeconds(15))
             items.get(i).click()
         }
     }
 
     fun submitSelection() {
         driver.wait(
-            condition = ExpectedConditions.elementToBeClickable(By.className(
-                "aui-button submit")),
+            condition = ExpectedConditions.elementToBeClickable(By.xpath(
+                ".//*[@class='aui-button submit']")),
             timeout = Duration.ofSeconds(5)
         ).click()
     }
 
+    private fun openColumnsList() {
+        driver.wait(
+            condition = ExpectedConditions.elementToBeClickable(By.xpath(
+                "//button[@title='Columns']")),
+            timeout = Duration.ofSeconds(15)
+        ).click()
+    }
+
+    private fun restoreDefaults() {
+        driver.wait(
+            condition = ExpectedConditions.elementToBeClickable(By.xpath(
+                ".//*[@class='aui-button aui-button-link restore-defaults']")),
+            timeout = Duration.ofSeconds(5)
+        ).click()
+        waitForColumnsRestored()
+    }
+
+    //default columns are restored with an AJAX request so we
+    //have to use thread.sleep() to wait for its execution
+    private fun waitForColumnsRestored() {
+        while (true) {
+            val isRestoreRequestComplete = (driver as JavascriptExecutor).executeScript("return jQuery.active == 0") as Boolean
+            if (isRestoreRequestComplete) {
+                break
+            }
+            Thread.sleep(100)
+        }
+    }
 }

--- a/custom-vu/src/main/kotlin/jces1209/vu/page/dashboard/DashboardPage.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/page/dashboard/DashboardPage.kt
@@ -5,7 +5,6 @@ import jces1209.vu.page.FalliblePage
 import jces1209.vu.wait
 import org.openqa.selenium.By
 import org.openqa.selenium.WebDriver
-import org.openqa.selenium.support.ui.ExpectedConditions
 import org.openqa.selenium.support.ui.ExpectedConditions.*
 import java.time.Duration
 
@@ -85,6 +84,14 @@ abstract class DashboardPage(
     }
 
     fun createGadget(projectName: String) {
+        val initialChartsCount = if (
+            driver.wait(presenceOfAllElementsLocatedBy(By.className("add-gadget-link")))
+                .size == 3
+            ) 0 else {
+            driver.wait(presenceOfAllElementsLocatedBy(By.className("bubble-chart-component-plot")))
+                .size
+        }
+
         driver
             .wait(elementToBeClickable(addGadgetLocator))
             .click()
@@ -98,21 +105,18 @@ abstract class DashboardPage(
             .first { it.isDisplayed }
             .click()
         driver
-            .wait(ExpectedConditions.invisibilityOfElementLocated(By.id("gadget-dialog")))
+            .wait(invisibilityOfElementLocated(By.id("gadget-dialog")))
 
-        val chartsNumber = driver
-            .findElements(By.className("bubble-chart-component-plot"))
-            .size
         driver
-            .findElement(By.cssSelector("[id$='project-filter-picker']"))
+            .wait(elementToBeClickable(By.cssSelector("[id$='project-filter-picker']")))
             .sendKeys(projectName)
         driver
             .wait(visibilityOfElementLocated(By.className("aui-list-item-link")))
             .click()
         driver
-            .findElement(By.cssSelector(".button.submit"))
+            .wait(elementToBeClickable(By.cssSelector(".button.submit")))
             .click()
         driver
-            .wait(numberOfElementsToBeMoreThan(By.cssSelector(".bubble-chart-component-plot, .aui-message-error"), chartsNumber))
+            .wait(numberOfElementsToBeMoreThan(By.cssSelector(".bubble-chart-component-plot, .aui-message-error"), initialChartsCount))
     }
 }

--- a/custom-vu/src/main/kotlin/jces1209/vu/page/issuenavigator/CloudIssueNavigator.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/page/issuenavigator/CloudIssueNavigator.kt
@@ -26,7 +26,9 @@ class CloudIssueNavigator(
                     presenceOfElementLocated(By.cssSelector("ol.issue-list")),
                     presenceOfElementLocated(By.id("issuetable")),
                     presenceOfElementLocated(By.id("issue-content")),
-                    presenceOfElementLocated(filterDetailsLocator)
+                    presenceOfElementLocated(filterDetailsLocator),
+                    presenceOfElementLocated(By.xpath("//div[@role='grid']")),
+                    presenceOfElementLocated(By.className("ghx-issue-content"))
                 ),
                 or(
                     presenceOfElementLocated(By.id("jira-issue-header")),
@@ -34,11 +36,16 @@ class CloudIssueNavigator(
                 ),
                 or(
                     presenceOfElementLocated(By.id("new-issue-body-container")),
-                    presenceOfElementLocated(By.className("issue-body-content"))
+                    presenceOfElementLocated(By.className("issue-body-content")),
+                    presenceOfElementLocated(By.xpath("//div[@data-test-id='issue.views.issue-details.issue-layout.issue-layout']"))
                 )
             ),
             and(
-                presenceOfElementLocated(By.cssSelector("[data-testid='issue-navigator.ui.card-list.card']")),
+                presenceOfElementLocated(By.id("summary-val")),
+                presenceOfElementLocated(By.id("status-val")),
+                presenceOfElementLocated(By.className("action-details"))
+            ),
+            and(
                 presenceOfElementLocated(By.cssSelector("[data-test-id='issue.views.issue-base.foundation.summary.heading']")),
                 presenceOfElementLocated(By.cssSelector("[data-test-id='issue.views.issue-base.foundation.status.status-field-wrapper']")),
                 presenceOfElementLocated(By.cssSelector("[data-test-id='issue.views.issue-details.issue-layout.footnote']"))

--- a/custom-vu/src/main/kotlin/jces1209/vu/utils/boards/BoardsFrequencyManager.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/utils/boards/BoardsFrequencyManager.kt
@@ -1,0 +1,50 @@
+package jces1209.vu.utils.boards
+
+import java.util.*
+
+/**
+ * Randomizes the board page generation depending on the board usage frequency.
+ */
+class BoardsFrequencyManager {
+
+    /**
+     * Contains data on the boards usage frequency and is used to emulate actual boards usage.
+     * The file should be stored in custom-vu/src/main/resources/.
+     * The template for file population can be found at /custom-vu/src/main/resources/BoardUsageFrequencyTemplate.csv.
+     */
+    //TODO Move the csv file path to the tenant properties
+    private val csvPropertyFile = "BoardUsageFrequency.csv"
+    private val boardsFromCsv = CsvBoardsReader.readBoardsFromCsv(csvPropertyFile)
+    private val boardsTotalWeight = calculateTotalBoardWeight()
+
+    fun getBoardByFrequency(): CsvBoard? {
+        if (boardsFromCsv.size > 0) {
+            return defineFrequentBoard(boardsFromCsv, boardsTotalWeight)
+        } else {
+            return null
+        }
+    }
+
+    private fun defineFrequentBoard(boardsList: MutableList<CsvBoard>?, totalWeight: Float): CsvBoard? {
+        //defining a default fallback board from the csv list in case the random frequent board is not generated
+        var resultBoard = boardsList?.get(Random().nextInt(boardsList.size))
+        val random = Random().nextFloat() * totalWeight
+        var countWeight = 0.0
+        for (board in boardsList!!) {
+            countWeight += board.frequency
+            if (countWeight >= random && countWeight > 0) {
+                resultBoard = board
+                break
+            }
+        }
+        return resultBoard
+    }
+
+    private fun calculateTotalBoardWeight(): Float {
+        var totalWeight = 0F
+        for (board in boardsFromCsv) {
+            totalWeight += board.frequency
+        }
+        return totalWeight
+    }
+}

--- a/custom-vu/src/main/kotlin/jces1209/vu/utils/boards/CsvBoard.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/utils/boards/CsvBoard.kt
@@ -1,0 +1,9 @@
+package jces1209.vu.utils.boards
+
+import java.net.URI
+
+data class CsvBoard(val id: String,
+                    val frequency: Float,
+                    val uri: URI,
+                    val boardType: String
+                    )

--- a/custom-vu/src/main/kotlin/jces1209/vu/utils/boards/CsvBoardsReader.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/utils/boards/CsvBoardsReader.kt
@@ -1,0 +1,46 @@
+package jces1209.vu.utils.boards
+
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
+import java.lang.IllegalStateException
+import java.net.URI
+
+/**
+ * Reads data from a csv file.
+ * At the moment it is used for reading boards usage frequency.
+ */
+object CsvBoardsReader {
+
+    private val logger: Logger = LogManager.getLogger(this::class.java)
+
+    fun readBoardsFromCsv(csvPropertyFile: String): MutableList<CsvBoard> {
+        val boardsFromCsv = mutableListOf<CsvBoard>()
+        var csvContent = String()
+        try {
+            csvContent = this::class.java.getResource("/$csvPropertyFile").readText()
+        } catch (exc: IllegalStateException) {
+            logger.debug("The csv file was not found, skipping...")
+        }
+        if (csvContent.isNotEmpty()) {
+            readCsvContentByLine(csvContent, boardsFromCsv)
+        }
+        return boardsFromCsv
+    }
+
+    private fun readCsvContentByLine(csvContent: String, boardsList: MutableList<CsvBoard>)  {
+        val csvLines = csvContent.split("\n").toTypedArray()
+        for (line in csvLines) {
+            if (line.isNotEmpty()) {
+                val parsedList = line.split(",").toTypedArray()
+                val id = parsedList[0]
+                val frequency = parsedList[1].toFloat()
+                val uri = URI(parsedList[2])
+                val type = parsedList[3].toLowerCase()
+                val csvBoard = CsvBoard(id, frequency, uri, type)
+                boardsList.add(csvBoard)
+            } else {
+                logger.debug("The csv line is blank, skipping...")
+            }
+        }
+    }
+}

--- a/custom-vu/src/main/kotlin/jces1209/vu/utils/cleanup/cloud/DashboardsCleanup.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/utils/cleanup/cloud/DashboardsCleanup.kt
@@ -1,0 +1,27 @@
+package jces1209.vu.utils.cleanup.cloud
+
+import jces1209.vu.api.CloudSettings
+import jces1209.vu.api.dashboard.CloudDashboardApi
+import jces1209.vu.api.dashboard.model.Dashboards
+import java.net.URI
+
+
+fun main(args: Array<String>) {
+    val dashboardApi = CloudDashboardApi(URI(CloudSettings.URL))
+    var dashboards: Dashboards
+    do {
+        dashboards = dashboardApi.getDashboards(CloudSettings.ACCOUNT_ID)
+        dashboards
+            .values
+            .parallelStream()
+            .forEach {
+                val dashboardId = it.id
+                repeat(3) {
+                    val response = dashboardApi.deleteDashboard(dashboardId)
+                    if (response.code() == 204) {
+                        return@repeat
+                    }
+                }
+            }
+    } while (!dashboards.isLast)
+}

--- a/custom-vu/src/main/kotlin/jces1209/vu/utils/cleanup/cloud/IssuesCleanup.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/utils/cleanup/cloud/IssuesCleanup.kt
@@ -1,0 +1,26 @@
+package jces1209.vu.utils.cleanup.cloud
+
+import jces1209.vu.api.CloudSettings
+import jces1209.vu.api.issue.CloudIssueApi
+import jces1209.vu.api.issue.model.Issues
+import java.net.URI
+
+fun main(args: Array<String>) {
+    val issueApi = CloudIssueApi(URI(CloudSettings.URL))
+    var issues: Issues
+    do {
+        issues = issueApi.getIssues(CloudSettings.ACCOUNT_ID, 0)
+        issues
+            .issues
+            .parallelStream()
+            .forEach {
+                val issueKey = it.key
+                repeat(3) {
+                    val response = issueApi.deleteIssue(issueKey)
+                    if (response.code() == 204) {
+                        return@repeat
+                    }
+                }
+            }
+    } while (issues.total != 0)
+}

--- a/custom-vu/src/main/kotlin/jces1209/vu/utils/cleanup/cloud/SprintsCleanup.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/utils/cleanup/cloud/SprintsCleanup.kt
@@ -1,0 +1,49 @@
+package jces1209.vu.utils.cleanup.cloud
+
+import jces1209.vu.api.CloudSettings
+import jces1209.vu.api.boards.CloudBoardApi
+import jces1209.vu.api.boards.model.Boards
+import jces1209.vu.api.sprint.CloudSprintApi
+import jces1209.vu.api.sprint.model.Sprints
+import java.net.URI
+
+
+fun main(args: Array<String>) {
+    val boardApi = CloudBoardApi(URI(CloudSettings.URL))
+    val sprintApi = CloudSprintApi(URI(CloudSettings.URL))
+    var boardsStartAt = 0
+    var boardsBatch: Boards
+    do {
+        boardsBatch = boardApi.getScrumBoards(boardsStartAt)
+        boardsBatch
+            .values
+            .parallelStream()
+            .forEach { board ->
+                var sprintsStartAt = 0
+                var sprintsBatch: Sprints
+                do {
+                    sprintsBatch = boardApi.getSprints(board.id, sprintsStartAt)
+                    if (null == sprintsBatch.values) {
+                        return@forEach
+                    } else {
+                        sprintsBatch
+                            .values!!
+                            .parallelStream()
+                            .forEach {
+                                val sprintId = it.id
+                                if (sprintId > CloudSettings.LAST_MIGRATED_SPRINT_ID) {
+                                    repeat(3) {
+                                        val response = sprintApi.deleteSprint(sprintId.toString())
+                                        if (response.code() == 204) {
+                                            return@repeat
+                                        }
+                                    }
+                                }
+                            }
+                        sprintsStartAt += boardApi.batchSize
+                    }
+                } while (!sprintsBatch.isLast)
+            }
+        boardsStartAt += boardApi.batchSize
+    } while (!boardsBatch.isLast)
+}

--- a/custom-vu/src/main/resources/BoardUsageFrequencyTemplate.csv
+++ b/custom-vu/src/main/resources/BoardUsageFrequencyTemplate.csv
@@ -1,0 +1,6 @@
+# Copy this as BoardUsageFrequency.csv and populate with actual data  in order to load boards for Jira Cloud depending on their actual usage frequency.
+# If you do not have actual usage frequency data or no longer want to use it, then delete BoardUsageFrequency.csv.
+# The current format for filling thhis file is as follows:
+# boardId,boardUsageFrequency,boardUrl,boardType(one of a type: ScrumSprintPage, ScrumBacklogPage, NextGenBoardPage, KanbanBoardPage)
+
+1,45.67,{jiraUri}/secure/RapidBoard.jspa?rapidView=1&view=planning&issueLimit=100,ScrumBacklogPage

--- a/gradle/dependency-locks/testCompile.lockfile
+++ b/gradle/dependency-locks/testCompile.lockfile
@@ -12,7 +12,7 @@ com.amazonaws:aws-java-sdk-s3:1.11.424
 com.amazonaws:aws-java-sdk-sts:1.11.424
 com.amazonaws:aws-java-sdk-support:1.11.424
 com.amazonaws:jmespath-java:1.11.424
-com.atlassian.performance.tools:aws-infrastructure:2.21.0
+com.atlassian.performance.tools:aws-infrastructure:2.22.2
 com.atlassian.performance.tools:aws-resources:1.5.0
 com.atlassian.performance.tools:concurrency:1.1.0
 com.atlassian.performance.tools:infrastructure:4.15.0

--- a/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -12,7 +12,7 @@ com.amazonaws:aws-java-sdk-s3:1.11.424
 com.amazonaws:aws-java-sdk-sts:1.11.424
 com.amazonaws:aws-java-sdk-support:1.11.424
 com.amazonaws:jmespath-java:1.11.424
-com.atlassian.performance.tools:aws-infrastructure:2.21.0
+com.atlassian.performance.tools:aws-infrastructure:2.22.2
 com.atlassian.performance.tools:aws-resources:1.5.0
 com.atlassian.performance.tools:concurrency:1.1.0
 com.atlassian.performance.tools:infrastructure:4.15.0

--- a/gradle/dependency-locks/testRuntime.lockfile
+++ b/gradle/dependency-locks/testRuntime.lockfile
@@ -12,7 +12,7 @@ com.amazonaws:aws-java-sdk-s3:1.11.424
 com.amazonaws:aws-java-sdk-sts:1.11.424
 com.amazonaws:aws-java-sdk-support:1.11.424
 com.amazonaws:jmespath-java:1.11.424
-com.atlassian.performance.tools:aws-infrastructure:2.21.0
+com.atlassian.performance.tools:aws-infrastructure:2.22.2
 com.atlassian.performance.tools:aws-resources:1.5.0
 com.atlassian.performance.tools:concurrency:1.1.0
 com.atlassian.performance.tools:infrastructure:4.15.0

--- a/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -12,7 +12,7 @@ com.amazonaws:aws-java-sdk-s3:1.11.424
 com.amazonaws:aws-java-sdk-sts:1.11.424
 com.amazonaws:aws-java-sdk-support:1.11.424
 com.amazonaws:jmespath-java:1.11.424
-com.atlassian.performance.tools:aws-infrastructure:2.21.0
+com.atlassian.performance.tools:aws-infrastructure:2.22.2
 com.atlassian.performance.tools:aws-resources:1.5.0
 com.atlassian.performance.tools:concurrency:1.1.0
 com.atlassian.performance.tools:infrastructure:4.15.0

--- a/src/test/kotlin/CohortProperties.kt
+++ b/src/test/kotlin/CohortProperties.kt
@@ -1,7 +1,7 @@
 import jces1209.vu.ConfigProperties
 import java.io.File
 import java.net.URI
-import java.util.*
+import java.util.Properties
 
 class CohortProperties(
     val jira: URI,

--- a/src/test/kotlin/CohortProperties.kt
+++ b/src/test/kotlin/CohortProperties.kt
@@ -7,7 +7,8 @@ class CohortProperties(
     val userName: String,
     val userPassword: String,
     val cohort: String,
-    val jiraType: String?
+    val jiraType: String?,
+    val configProperties: String?
 ) {
     companion object {
         fun load(secretsName: String): CohortProperties {
@@ -19,7 +20,8 @@ class CohortProperties(
                 userName = properties.getProperty("user.name")!!,
                 userPassword = properties.getProperty("user.password")!!,
                 cohort = properties.getProperty("cohort")!!,
-                jiraType = properties.getProperty("jira.type")
+                jiraType = properties.getProperty("jira.type"),
+                configProperties = properties.getProperty("configProperties")
             )
         }
     }

--- a/src/test/kotlin/CohortProperties.kt
+++ b/src/test/kotlin/CohortProperties.kt
@@ -1,3 +1,4 @@
+import jces1209.vu.ConfigProperties
 import java.io.File
 import java.net.URI
 import java.util.*
@@ -8,7 +9,7 @@ class CohortProperties(
     val userPassword: String,
     val cohort: String,
     val jiraType: String?,
-    val configProperties: String?
+    val trafficConfigObj: Properties?
 ) {
     companion object {
         fun load(secretsName: String): CohortProperties {
@@ -21,7 +22,7 @@ class CohortProperties(
                 userPassword = properties.getProperty("user.password")!!,
                 cohort = properties.getProperty("cohort")!!,
                 jiraType = properties.getProperty("jira.type"),
-                configProperties = properties.getProperty("configProperties")
+                trafficConfigObj = ConfigProperties.load(properties.getProperty("config.trafficConfigFile"))
             )
         }
     }

--- a/src/test/kotlin/JiraPerformanceComparisonIT.kt
+++ b/src/test/kotlin/JiraPerformanceComparisonIT.kt
@@ -21,7 +21,6 @@ import org.junit.Test
 import java.io.File
 import java.nio.file.Paths
 import java.time.Duration
-import java.util.*
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors.newCachedThreadPool
@@ -36,7 +35,9 @@ class JiraPerformanceComparisonIT {
     }
 
     private fun listFileNameForCohort(): List<String> {
-        return File("./cohort-secrets").listFiles()?.filter { fileName -> fileName.extension == "properties" }!!.map { f -> f.name }.toList()
+        return File("./cohort-secrets").listFiles()?.
+        filter { fileName -> fileName.extension == "properties" }!!.
+        map { f -> f.name }.toList()
     }
 
     @Test

--- a/src/test/kotlin/JiraPerformanceComparisonIT.kt
+++ b/src/test/kotlin/JiraPerformanceComparisonIT.kt
@@ -21,6 +21,7 @@ import org.junit.Test
 import java.io.File
 import java.nio.file.Paths
 import java.time.Duration
+import java.util.*
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors.newCachedThreadPool

--- a/src/test/kotlin/JiraPerformanceComparisonIT.kt
+++ b/src/test/kotlin/JiraPerformanceComparisonIT.kt
@@ -121,6 +121,8 @@ class JiraPerformanceComparisonIT {
             userName = properties.userName,
             password = properties.userPassword
         )
+        println("properties.configProperties")
+        println(properties.configProperties)
         val behavior = quality.behave(scenario, properties.configProperties)
             .let { VirtualUserBehavior.Builder(it) }
             .build()

--- a/src/test/kotlin/JiraPerformanceComparisonIT.kt
+++ b/src/test/kotlin/JiraPerformanceComparisonIT.kt
@@ -35,8 +35,7 @@ class JiraPerformanceComparisonIT {
     }
 
     private fun listFileNameForCohort(): List<String> {
-        return File("./cohort-secrets").listFiles()?.
-        filter { fileName -> fileName.extension == "properties" }!!.map { f -> f.name }.toList()
+        return File("./cohort-secrets").listFiles()?.filter { fileName -> fileName.extension == "properties" }!!.map { f -> f.name }.toList()
     }
 
     @Test
@@ -70,7 +69,7 @@ class JiraPerformanceComparisonIT {
             pool.submitWithLogContext(properties.cohort) {
                 benchmark(properties, JiraCloudScenario::class.java, quality)
             }
-        } else{
+        } else {
             pool.submitWithLogContext(properties.cohort) {
                 benchmark(properties, JiraDcScenario::class.java, quality)
             }
@@ -98,7 +97,7 @@ class JiraPerformanceComparisonIT {
         val cohort = properties.cohort
         val resultsTarget = workspace.directory.resolve("vu-results").resolve(cohort)
         val provisioned = quality
-            .provide()
+            .provide(properties.configProperties)
             .obtainVus(resultsTarget, workspace.directory)
         val virtualUsers = provisioned.virtualUsers
         return try {
@@ -122,7 +121,7 @@ class JiraPerformanceComparisonIT {
             userName = properties.userName,
             password = properties.userPassword
         )
-        val behavior = quality.behave(scenario)
+        val behavior = quality.behave(scenario, properties.configProperties)
             .let { VirtualUserBehavior.Builder(it) }
             .build()
         return VirtualUserOptions(target, behavior)

--- a/src/test/kotlin/JiraPerformanceComparisonIT.kt
+++ b/src/test/kotlin/JiraPerformanceComparisonIT.kt
@@ -97,7 +97,7 @@ class JiraPerformanceComparisonIT {
         val cohort = properties.cohort
         val resultsTarget = workspace.directory.resolve("vu-results").resolve(cohort)
         val provisioned = quality
-            .provide(properties.configProperties)
+            .provide(properties.trafficConfigObj)
             .obtainVus(resultsTarget, workspace.directory)
         val virtualUsers = provisioned.virtualUsers
         return try {
@@ -121,9 +121,8 @@ class JiraPerformanceComparisonIT {
             userName = properties.userName,
             password = properties.userPassword
         )
-        println("properties.configProperties")
-        println(properties.configProperties)
-        val behavior = quality.behave(scenario, properties.configProperties)
+
+        val behavior = quality.behave(scenario, properties.trafficConfigObj)
             .let { VirtualUserBehavior.Builder(it) }
             .build()
         return VirtualUserOptions(target, behavior)

--- a/src/test/kotlin/jces1209/AwsVus.kt
+++ b/src/test/kotlin/jces1209/AwsVus.kt
@@ -23,7 +23,7 @@ import com.atlassian.performance.tools.io.api.ensureDirectory
 import jces1209.vu.ConfigProperties
 import java.nio.file.Path
 import java.time.Duration
-import java.util.*
+import java.util.Properties
 import java.util.concurrent.CompletableFuture
 
 class AwsVus(

--- a/src/test/kotlin/jces1209/AwsVus.kt
+++ b/src/test/kotlin/jces1209/AwsVus.kt
@@ -3,7 +3,6 @@ package jces1209
 import com.amazonaws.auth.AWSCredentialsProviderChain
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
 import com.amazonaws.auth.EC2ContainerCredentialsProviderWrapper
-import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.regions.Regions
 import com.amazonaws.regions.Regions.*
@@ -97,10 +96,6 @@ class AwsVus(
     private fun prepareAws() = Aws.Builder(region)
         .credentialsProvider(
             AWSCredentialsProviderChain(
-                STSAssumeRoleSessionCredentialsProvider.Builder(
-                    "arn:aws:iam::695067801333:role/server-gdn-bamboo",
-                    UUID.randomUUID().toString()
-                ).build(),
                 ProfileCredentialsProvider("jpt-dev"),
                 EC2ContainerCredentialsProviderWrapper(),
                 DefaultAWSCredentialsProviderChain()

--- a/src/test/kotlin/jces1209/AwsVus.kt
+++ b/src/test/kotlin/jces1209/AwsVus.kt
@@ -20,10 +20,10 @@ import com.atlassian.performance.tools.awsinfrastructure.api.virtualusers.Provis
 import com.atlassian.performance.tools.infrastructure.api.virtualusers.DirectResultsTransport
 import com.atlassian.performance.tools.io.api.dereference
 import com.atlassian.performance.tools.io.api.ensureDirectory
-import jces1209.vu.ConfigProperties
 import java.nio.file.Path
 import java.time.Duration
 import java.util.Properties
+import java.util.UUID
 import java.util.concurrent.CompletableFuture
 
 class AwsVus(

--- a/src/test/kotlin/jces1209/AwsVus.kt
+++ b/src/test/kotlin/jces1209/AwsVus.kt
@@ -64,7 +64,7 @@ class AwsVus(
             ).provision()
         }
         val provisioned = MulticastVirtualUsersFormula.Builder(
-                nodes = (configProperties?.getProperty("nodes"))?.toInt() ?: 6,
+                nodes = (configProperties?.getProperty("setting.nodes"))?.toInt() ?: 6,
                 shadowJar = dereference("jpt.virtual-users.shadow-jar")
             )
             .browser(Chromium77())

--- a/src/test/kotlin/jces1209/AwsVus.kt
+++ b/src/test/kotlin/jces1209/AwsVus.kt
@@ -31,7 +31,7 @@ class AwsVus(
     private val region: Regions,
     private val vpcId: String?,
     private val subnetId: String?,
-    private val configProperties: String?
+    private val configProperties: Properties?
 ) : VirtualUsersSource {
 
     private val lifespan = Duration.ofMinutes(10) + duration
@@ -64,7 +64,7 @@ class AwsVus(
             ).provision()
         }
         val provisioned = MulticastVirtualUsersFormula.Builder(
-                nodes = getProvisionedNodes(),
+                nodes = (configProperties?.getProperty("nodes"))?.toInt() ?: 6,
                 shadowJar = dereference("jpt.virtual-users.shadow-jar")
             )
             .browser(Chromium77())
@@ -85,14 +85,6 @@ class AwsVus(
                 dependency = sshKey.remote
             )
         )
-    }
-
-    private fun getProvisionedNodes(): Int {
-        return if(configProperties.isNullOrEmpty()){
-            6
-        }else{
-            (ConfigProperties.load(configProperties).nodes) ?: 6
-        }
     }
 
     private fun workAroundDirectResultTransportRaceCondition(

--- a/src/test/kotlin/jces1209/BenchmarkQuality.kt
+++ b/src/test/kotlin/jces1209/BenchmarkQuality.kt
@@ -2,7 +2,8 @@ package jces1209
 
 import com.atlassian.performance.tools.jiraactions.api.scenario.Scenario
 import com.atlassian.performance.tools.virtualusers.api.config.VirtualUserBehavior
-import java.util.*
+import java.util.Properties
+
 
 interface BenchmarkQuality {
 

--- a/src/test/kotlin/jces1209/BenchmarkQuality.kt
+++ b/src/test/kotlin/jces1209/BenchmarkQuality.kt
@@ -2,13 +2,14 @@ package jces1209
 
 import com.atlassian.performance.tools.jiraactions.api.scenario.Scenario
 import com.atlassian.performance.tools.virtualusers.api.config.VirtualUserBehavior
+import java.util.*
 
 interface BenchmarkQuality {
 
-    fun provide(configProperties: String?): VirtualUsersSource
+    fun provide(trafficConfigObj: Properties?): VirtualUsersSource
 
     fun behave(
         scenario: Class<out Scenario>,
-        configProperties: String?
+        trafficConfigObj: Properties?
     ): VirtualUserBehavior
 }

--- a/src/test/kotlin/jces1209/BenchmarkQuality.kt
+++ b/src/test/kotlin/jces1209/BenchmarkQuality.kt
@@ -5,9 +5,10 @@ import com.atlassian.performance.tools.virtualusers.api.config.VirtualUserBehavi
 
 interface BenchmarkQuality {
 
-    fun provide(): VirtualUsersSource
+    fun provide(configProperties: String?): VirtualUsersSource
 
     fun behave(
-        scenario: Class<out Scenario>
+        scenario: Class<out Scenario>,
+        configProperties: String?
     ): VirtualUserBehavior
 }

--- a/src/test/kotlin/jces1209/QuickAndDirty.kt
+++ b/src/test/kotlin/jces1209/QuickAndDirty.kt
@@ -5,7 +5,7 @@ import com.atlassian.performance.tools.virtualusers.api.VirtualUserLoad
 import com.atlassian.performance.tools.virtualusers.api.config.VirtualUserBehavior
 import jces1209.vu.Firefox
 import java.time.Duration
-import java.util.*
+import java.util.Properties
 
 class QuickAndDirty : BenchmarkQuality {
 

--- a/src/test/kotlin/jces1209/QuickAndDirty.kt
+++ b/src/test/kotlin/jces1209/QuickAndDirty.kt
@@ -8,11 +8,11 @@ import java.time.Duration
 
 class QuickAndDirty : BenchmarkQuality {
 
-    override fun provide(readConfigProperties: String?): VirtualUsersSource = LocalVus()
+    override fun provide(configProperties: String?): VirtualUsersSource = LocalVus()
 
     override fun behave(
-            scenario: Class<out Scenario>,
-            readConfigProperties: String?
+        scenario: Class<out Scenario>,
+        configProperties: String?
     ): VirtualUserBehavior = VirtualUserBehavior.Builder(scenario)
         .browser(Firefox::class.java) // local Chrome is flaky around version 80, so let's use Firefox
         .load(

--- a/src/test/kotlin/jces1209/QuickAndDirty.kt
+++ b/src/test/kotlin/jces1209/QuickAndDirty.kt
@@ -8,10 +8,11 @@ import java.time.Duration
 
 class QuickAndDirty : BenchmarkQuality {
 
-    override fun provide(): VirtualUsersSource = LocalVus()
+    override fun provide(readConfigProperties: String?): VirtualUsersSource = LocalVus()
 
     override fun behave(
-        scenario: Class<out Scenario>
+            scenario: Class<out Scenario>,
+            readConfigProperties: String?
     ): VirtualUserBehavior = VirtualUserBehavior.Builder(scenario)
         .browser(Firefox::class.java) // local Chrome is flaky around version 80, so let's use Firefox
         .load(

--- a/src/test/kotlin/jces1209/QuickAndDirty.kt
+++ b/src/test/kotlin/jces1209/QuickAndDirty.kt
@@ -5,14 +5,15 @@ import com.atlassian.performance.tools.virtualusers.api.VirtualUserLoad
 import com.atlassian.performance.tools.virtualusers.api.config.VirtualUserBehavior
 import jces1209.vu.Firefox
 import java.time.Duration
+import java.util.*
 
 class QuickAndDirty : BenchmarkQuality {
 
-    override fun provide(configProperties: String?): VirtualUsersSource = LocalVus()
+    override fun provide(trafficConfigObj: Properties?): VirtualUsersSource = LocalVus()
 
     override fun behave(
         scenario: Class<out Scenario>,
-        configProperties: String?
+        trafficConfigObj: Properties?
     ): VirtualUserBehavior = VirtualUserBehavior.Builder(scenario)
         .browser(Firefox::class.java) // local Chrome is flaky around version 80, so let's use Firefox
         .load(

--- a/src/test/kotlin/jces1209/SlowAndMeaningful.kt
+++ b/src/test/kotlin/jces1209/SlowAndMeaningful.kt
@@ -8,7 +8,7 @@ import com.atlassian.performance.tools.virtualusers.api.browsers.Browser
 import com.atlassian.performance.tools.virtualusers.api.config.VirtualUserBehavior
 import jces1209.vu.EagerChromeBrowser
 import java.time.Duration
-import java.util.*
+import java.util.Properties
 
 class SlowAndMeaningful private constructor(
     private val browser: Class<out Browser>,
@@ -35,14 +35,11 @@ class SlowAndMeaningful private constructor(
         var virtualUser = 72
         var ramp = 1L
         var maxOverallLoad = 15.0
-
         if (null != trafficConfigObj) {
-
             virtualUser = trafficConfigObj.getProperty("setting.virtualUsers")?.toInt() ?: 72
             ramp = trafficConfigObj.getProperty("setting.rampInMinute")?.toLong() ?: 1
             maxOverallLoad = trafficConfigObj.getProperty("setting.maxOverallLoad")?.toDouble() ?: 15.0
         }
-
         return VirtualUserLoad.Builder()
             .virtualUsers(virtualUser)
             .ramp(Duration.ofMinutes(ramp))
@@ -54,8 +51,8 @@ class SlowAndMeaningful private constructor(
     class Builder {
         private var browser: Class<out Browser> = EagerChromeBrowser::class.java
         private var region: Regions = Regions.US_EAST_1
-        private var duration: Duration = System.getenv("duration").takeUnless { it.isNullOrEmpty() }?.toLong()?.let { Duration.ofMinutes(it) }
-            ?:Duration.ofMinutes(20)
+        private var duration: Duration = System.getenv("duration")
+            .takeUnless { it.isNullOrEmpty() }?.toLong()?.let { Duration.ofMinutes(it) } ?: Duration.ofMinutes(20)
 
         fun browser(browser: Class<out Browser>) = apply { this.browser = browser }
         fun region(region: Regions) = apply { this.region = region }

--- a/src/test/kotlin/jces1209/SlowAndMeaningful.kt
+++ b/src/test/kotlin/jces1209/SlowAndMeaningful.kt
@@ -70,6 +70,3 @@ class SlowAndMeaningful private constructor(
         }
     }
 }
-
-
-

--- a/src/test/kotlin/jces1209/SlowAndMeaningful.kt
+++ b/src/test/kotlin/jces1209/SlowAndMeaningful.kt
@@ -22,10 +22,10 @@ class SlowAndMeaningful private constructor(
         configProperties
     )
 
-    override fun behave(scenario: Class<out Scenario>, readConfigProperties: String?): VirtualUserBehavior = VirtualUserBehavior.Builder(scenario)
+    override fun behave(scenario: Class<out Scenario>, configProperties: String?): VirtualUserBehavior = VirtualUserBehavior.Builder(scenario)
         .browser(browser)
         .load(
-            getVirtualUserLoad(readConfigProperties)
+            getVirtualUserLoad(configProperties)
         )
         .skipSetup(true)
         .seed(12345L)

--- a/src/test/kotlin/jces1209/SlowAndMeaningful.kt
+++ b/src/test/kotlin/jces1209/SlowAndMeaningful.kt
@@ -38,10 +38,9 @@ class SlowAndMeaningful private constructor(
 
         if (null != trafficConfigObj) {
 
-            virtualUser = trafficConfigObj.getProperty("virtualUser")?.toInt() ?: 72
-            ramp = trafficConfigObj.getProperty("ramp")?.toLong() ?: 1
-            maxOverallLoad = trafficConfigObj.getProperty("maxOverallLoad")?.toDouble() ?: 15.0
-
+            virtualUser = trafficConfigObj.getProperty("setting.virtualUsers")?.toInt() ?: 72
+            ramp = trafficConfigObj.getProperty("setting.rampInMinute")?.toLong() ?: 1
+            maxOverallLoad = trafficConfigObj.getProperty("setting.maxOverallLoad")?.toDouble() ?: 15.0
         }
 
         return VirtualUserLoad.Builder()

--- a/src/test/kotlin/jces1209/SlowAndMeaningful.kt
+++ b/src/test/kotlin/jces1209/SlowAndMeaningful.kt
@@ -55,7 +55,8 @@ class SlowAndMeaningful private constructor(
     class Builder {
         private var browser: Class<out Browser> = EagerChromeBrowser::class.java
         private var region: Regions = Regions.US_EAST_1
-        private var duration: Duration = Duration.ofMinutes(20)
+        private var duration: Duration = System.getenv("duration").takeUnless { it.isNullOrEmpty() }?.toLong()?.let { Duration.ofMinutes(it) }
+            ?:Duration.ofMinutes(20)
 
         fun browser(browser: Class<out Browser>) = apply { this.browser = browser }
         fun region(region: Regions) = apply { this.region = region }


### PR DESCRIPTION
**Change Details:**

- This change will allow configurable distribution/action weights
- We will have properties file inside `custom-vu/src/main/resources/<jira_url_hostname.properties>` and we have one environment variable if environment variable present it will read those parameters from the properties file else it will use default values  (Class - ScenarioSimilarities.kt)
- Along with action distribution, load will be configurable (virtual users, nodes, ramp, and maxOverallLoad) the values of these parameters will be in the same properties file but as these values are handled via different classes (Awsvu.kt and SlowAndMeaningful.kt) and to access the properties file name will pass the properties name via nullable field in cohort-secret/<.properties> file.

example properties file
`action.createIssue=0
action.workAnIssue=55
action.manageProjects=5
action.projectSummary=5
action.browseProjects=5
action.browseBoards=5
action.viewBoard=30
action.workOnDashboard=5
action.workOnSprint=0
action.browseProjectIssues=5
action.workOnBacklog=0
action.workOnSearch=5
action.workOnTopBar=5
action.workOnWorkflow=50
action.bulkEdit=0
action.workOnTransition=5
action.browseWorkflows=5
action.browseFieldScreens=5
action.browseFieldConfigurations=5
action.browseCustomFields=5
action.browseIssueTypes=5
action.browseProjectRoles=5

setting.virtualUsers=72
setting.rampInMinute=1
setting.maxOverallLoad=15.0
setting.nodes=6`
