### PR TITLE
Configurable Traffic distribution

### DIFF
--- a/custom-vu/src/main/kotlin/jces1209/vu/ConfigProperties.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/ConfigProperties.kt
@@ -1,0 +1,21 @@
+package jces1209.vu
+
+import java.io.InputStream
+import java.util.Properties
+
+class ConfigProperties {
+
+    companion object {
+        lateinit var properties: Properties
+
+        fun load(resourceName: String?): Properties {
+            val fileReadStream: InputStream? = this::class.java.getResourceAsStream("/$resourceName")
+
+            properties = Properties()
+            fileReadStream?.use {
+                properties.load(it)
+            }
+            return properties
+        }
+    }
+}

--- a/custom-vu/src/main/kotlin/jces1209/vu/ScenarioSimilarities.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/ScenarioSimilarities.kt
@@ -234,30 +234,38 @@ class ScenarioSimilarities(
         browseProjectRoles: Action,
         manageProjectPermissions: Action
     ): List<Action> {
+        val readTrafficShapeConfig = System.getenv("readTrafficShapeConfig")
+        var properties = Properties()
+
+        if (!readTrafficShapeConfig.isNullOrEmpty()) {
+            val resourceName = TrafficDataParser.parseData(jira.base.host, readTrafficShapeConfig)
+            properties = ConfigProperties.load(resourceName)
+        }
+
         val exploreData = listOf(browseProjects, browseFilters, browseBoards)
         val spreadOut = mapOf(
-            createIssue to 0, // 5 if we can mutate data
-            workAnIssue to 55,
-            manageProjects to 5,
-            projectSummary to 5,
-            browseProjects to 5,
-            browseBoards to 5,
-            viewBoard to 30,
-            workOnDashboard to 5,
-            workOnSprint to 0, // 3 if we can mutate data
-            browseProjectIssues to 5,
-            workOnBacklog to 0, // 3 if we can mutate data
-            workOnSearch to 5,
-            workOnTopBar to 5,
-            bulkEdit to 0, // 5 if we can mutate data
-            workOnTransition to 5,
-            workOnWorkflow to 5,
-            browseFieldScreens to 5,
-            browseFieldConfigurations to 5,
-            browseCustomFields to 5,
-            browseIssueTypes to 5,
-            browseProjectRoles to 5,
-            manageProjectPermissions to 5
+            createIssue to ((properties.getProperty("action.createIssue")?.toInt()) ?: 0), // 5 if we can mutate data
+            workAnIssue to ((properties.getProperty("action.workAnIssue")?.toInt()) ?: 55),
+            manageProjects to ((properties.getProperty("action.manageProjects")?.toInt()) ?: 5),
+            projectSummary to ((properties.getProperty("action.projectSummary")?.toInt()) ?: 5),
+            browseProjects to ((properties.getProperty("action.browseProjects")?.toInt()) ?: 5),
+            browseBoards to ((properties.getProperty("action.browseBoards")?.toInt()) ?: 5),
+            viewBoard to ((properties.getProperty("action.viewBoard")?.toInt()) ?: 30),
+            workOnDashboard to ((properties.getProperty("action.workOnDashboard")?.toInt()) ?: 5),
+            workOnSprint to ((properties.getProperty("action.workOnSprint")?.toInt()) ?: 0), // 3 if we can mutate data
+            browseProjectIssues to ((properties.getProperty("action.browseProjectIssues")?.toInt()) ?: 5),
+            workOnBacklog to ((properties.getProperty("action.workOnBacklog")?.toInt()) ?: 0), // 3 if we can mutate data
+            workOnSearch to ((properties.getProperty("action.workOnSearch")?.toInt()) ?: 5),
+            workOnTopBar to ((properties.getProperty("action.workOnTopBar")?.toInt()) ?: 5),
+            bulkEdit to ((properties.getProperty("action.bulkEdit")?.toInt()) ?: 0), // 5 if we can mutate data
+            workOnTransition to ((properties.getProperty("action.workOnTransition")?.toInt()) ?: 5),
+            workOnWorkflow to ((properties.getProperty("action.workOnWorkflow")?.toInt()) ?: 5),
+            browseFieldScreens to ((properties.getProperty("action.browseFieldScreens")?.toInt()) ?: 5),
+            browseFieldConfigurations to ((properties.getProperty("action.browseFieldConfigurations")?.toInt()) ?: 5),
+            browseCustomFields to ((properties.getProperty("action.browseCustomFields")?.toInt()) ?: 5),
+            browseIssueTypes to ((properties.getProperty("action.browseIssueTypes")?.toInt()) ?: 5),
+            browseProjectRoles to ((properties.getProperty("action.browseProjectRoles")?.toInt()) ?: 5),
+            manageProjectPermissions to ((properties.getProperty("action.manageProjectPermissions")?.toInt()) ?: 5)
         )
             .map { (action, proportion) -> Collections.nCopies(proportion, action) }
             .flatten()

--- a/custom-vu/src/main/kotlin/jces1209/vu/TrafficDataParser.kt
+++ b/custom-vu/src/main/kotlin/jces1209/vu/TrafficDataParser.kt
@@ -1,0 +1,24 @@
+package jces1209.vu
+
+import java.io.StringReader
+import java.util.Base64
+import javax.json.Json
+import javax.json.JsonReader
+
+class TrafficDataParser {
+
+    companion object {
+
+        fun parseData(hostName: String, readEnvTrafficShapeConfig: String): String {
+            val decodedBytes = Base64.getDecoder().decode(readEnvTrafficShapeConfig)
+            val decodedString = String(decodedBytes)
+            val jsonReader: JsonReader = Json.createReader(StringReader(decodedString))
+            var propertiesFileName = ""
+            jsonReader.use {
+                val obj: javax.json.JsonObject = jsonReader.readObject()
+                propertiesFileName = obj.getString(hostName)
+            }
+            return propertiesFileName
+        }
+    }
+}

--- a/src/test/kotlin/CohortProperties.kt
+++ b/src/test/kotlin/CohortProperties.kt
@@ -1,13 +1,16 @@
+import jces1209.vu.ConfigProperties
 import java.io.File
 import java.net.URI
-import java.util.*
+import java.util.Properties
+
 
 class CohortProperties(
     val jira: URI,
     val userName: String,
     val userPassword: String,
     val cohort: String,
-    val jiraType: String?
+    val jiraType: String?,
+    val trafficConfigObj: Properties?
 ) {
     companion object {
         fun load(secretsName: String): CohortProperties {
@@ -19,7 +22,8 @@ class CohortProperties(
                 userName = properties.getProperty("user.name")!!,
                 userPassword = properties.getProperty("user.password")!!,
                 cohort = properties.getProperty("cohort")!!,
-                jiraType = properties.getProperty("jira.type")
+                jiraType = properties.getProperty("jira.type"),
+                trafficConfigObj = ConfigProperties.load(properties.getProperty("config.trafficConfigFile"))
             )
         }
     }

--- a/src/test/kotlin/JiraPerformanceComparisonIT.kt
+++ b/src/test/kotlin/JiraPerformanceComparisonIT.kt
@@ -98,7 +98,7 @@ class JiraPerformanceComparisonIT {
         val cohort = properties.cohort
         val resultsTarget = workspace.directory.resolve("vu-results").resolve(cohort)
         val provisioned = quality
-            .provide()
+            .provide(properties.trafficConfigObj)
             .obtainVus(resultsTarget, workspace.directory)
         val virtualUsers = provisioned.virtualUsers
         return try {
@@ -122,7 +122,7 @@ class JiraPerformanceComparisonIT {
             userName = properties.userName,
             password = properties.userPassword
         )
-        val behavior = quality.behave(scenario)
+        val behavior = quality.behave(scenario,properties.trafficConfigObj)
             .let { VirtualUserBehavior.Builder(it) }
             .build()
         return VirtualUserOptions(target, behavior)

--- a/src/test/kotlin/jces1209/AwsVus.kt
+++ b/src/test/kotlin/jces1209/AwsVus.kt
@@ -21,14 +21,16 @@ import com.atlassian.performance.tools.io.api.dereference
 import com.atlassian.performance.tools.io.api.ensureDirectory
 import java.nio.file.Path
 import java.time.Duration
-import java.util.*
+import java.util.UUID
+import java.util.Properties
 import java.util.concurrent.CompletableFuture
 
 class AwsVus(
     duration: Duration,
     private val region: Regions,
     private val vpcId: String?,
-    private val subnetId: String?
+    private val subnetId: String?,
+    private val configProperties: Properties?
 ) : VirtualUsersSource {
 
     private val lifespan = Duration.ofMinutes(10) + duration
@@ -61,7 +63,7 @@ class AwsVus(
             ).provision()
         }
         val provisioned = MulticastVirtualUsersFormula.Builder(
-                nodes = 6,
+                nodes = (configProperties?.getProperty("setting.nodes"))?.toInt() ?: 6,
                 shadowJar = dereference("jpt.virtual-users.shadow-jar")
             )
             .browser(Chromium77())

--- a/src/test/kotlin/jces1209/BenchmarkQuality.kt
+++ b/src/test/kotlin/jces1209/BenchmarkQuality.kt
@@ -2,12 +2,14 @@ package jces1209
 
 import com.atlassian.performance.tools.jiraactions.api.scenario.Scenario
 import com.atlassian.performance.tools.virtualusers.api.config.VirtualUserBehavior
+import java.util.*
 
 interface BenchmarkQuality {
 
-    fun provide(): VirtualUsersSource
+    fun provide(trafficConfigObj: Properties?): VirtualUsersSource
 
     fun behave(
-        scenario: Class<out Scenario>
+        scenario: Class<out Scenario>,
+        trafficConfigObj: Properties?
     ): VirtualUserBehavior
 }

--- a/src/test/kotlin/jces1209/QuickAndDirty.kt
+++ b/src/test/kotlin/jces1209/QuickAndDirty.kt
@@ -5,13 +5,15 @@ import com.atlassian.performance.tools.virtualusers.api.VirtualUserLoad
 import com.atlassian.performance.tools.virtualusers.api.config.VirtualUserBehavior
 import jces1209.vu.Firefox
 import java.time.Duration
+import java.util.*
 
 class QuickAndDirty : BenchmarkQuality {
 
-    override fun provide(): VirtualUsersSource = LocalVus()
+    override fun provide(trafficConfigObj: Properties?): VirtualUsersSource = LocalVus()
 
     override fun behave(
-        scenario: Class<out Scenario>
+        scenario: Class<out Scenario>,
+        trafficConfigObj: Properties?
     ): VirtualUserBehavior = VirtualUserBehavior.Builder(scenario)
         .browser(Firefox::class.java) // local Chrome is flaky around version 80, so let's use Firefox
         .load(


### PR DESCRIPTION
**Change Details:**

This change will allow configurable distribution/action weights
We will have properties file inside custom-vu/src/main/resources/<jira_url_hostname.properties> and we have one environment variable if environment variable present it will read those parameters from the properties file else it will use default values (Class - ScenarioSimilarities.kt)
Along with action distribution, load will be configurable (virtual users, nodes, ramp, and maxOverallLoad) the values of these parameters will be in the same properties file but as these values are handled via different classes (Awsvu.kt and SlowAndMeaningful.kt) and to access the properties file name will pass the properties name via nullable field in cohort-secret/<.properties> file.

example properties file
`action.createIssue=0
action.workAnIssue=55
action.manageProjects=5
action.projectSummary=5
action.browseProjects=5
action.browseBoards=5
action.viewBoard=30
action.workOnDashboard=5
action.workOnSprint=0
action.browseProjectIssues=5
action.workOnBacklog=0
action.workOnSearch=5
action.workOnTopBar=5
action.workOnWorkflow=50
action.bulkEdit=0
action.workOnTransition=5
action.browseWorkflows=5
action.browseFieldScreens=5
action.browseFieldConfigurations=5
action.browseCustomFields=5
action.browseIssueTypes=5
action.browseProjectRoles=5

setting.virtualUsers=72
setting.rampInMinute=1
setting.maxOverallLoad=15.0
setting.nodes=6